### PR TITLE
fix: remove reconnect delay for exit_standby event

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -266,8 +266,6 @@ async def event_handler():
 async def event_handler():
     global configuredAppleTvs
 
-    await asyncio.sleep(2)
-
     for appleTv in configuredAppleTvs:
         await configuredAppleTvs[appleTv].connect()
 


### PR DESCRIPTION
The exit_standby event will be delayed by the Remote Two until the system reports a routable network interface. This allows for an immediate reconnect of the integration, without retries.

Relates to unfoldedcircle/feature-and-bug-tracker#320