### PR TITLE
fix: automatically migrate old configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Fixed
+- Automatically migrate old configuration file at startup and configuration flow, otherwise the device must be paired again.
+
 ---
 
 ## v0.13.1 - 2024-03-07

--- a/intg-appletv/discover.py
+++ b/intg-appletv/discover.py
@@ -15,7 +15,9 @@ from pyatv.const import DeviceModel
 _LOG = logging.getLogger(__name__)
 
 
-async def apple_tvs(loop: AbstractEventLoop, hosts: list[str] | None = None) -> list[pyatv.interface.BaseConfig]:
+async def apple_tvs(
+    loop: AbstractEventLoop, identifier: str | set[str] | None = None, hosts: list[str] | None = None
+) -> list[pyatv.interface.BaseConfig]:
     """Discover Apple TVs on the network using pyatv.scan."""
     if hosts:
         _LOG.info("Connecting to %s", hosts)
@@ -24,7 +26,7 @@ async def apple_tvs(loop: AbstractEventLoop, hosts: list[str] | None = None) -> 
 
     # extra safety, if anything goes wrong here the reconnection logic is dead
     try:
-        atvs = await pyatv.scan(loop, hosts=hosts)
+        atvs = await pyatv.scan(loop, identifier=identifier, hosts=hosts)
         res = []
 
         for tv in atvs:

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -544,6 +544,7 @@ async def main():
     level = os.getenv("UC_LOG_LEVEL", "DEBUG").upper()
     logging.getLogger("tv").setLevel(level)
     logging.getLogger("driver").setLevel(level)
+    logging.getLogger("config").setLevel(level)
     logging.getLogger("discover").setLevel(level)
     logging.getLogger("setup_flow").setLevel(level)
 
@@ -551,6 +552,8 @@ async def main():
 
     # load paired devices
     config.devices = config.Devices(api.config_dir_path, on_device_added, on_device_removed)
+    # best effort migration (if required): network might not be available during startup
+    await config.devices.migrate()
     # and register them as available devices.
     # Note: device will be moved to configured devices with the subscribe_events request!
     # This will also start the device connection.

--- a/intg-appletv/setup_flow.py
+++ b/intg-appletv/setup_flow.py
@@ -143,6 +143,10 @@ async def _handle_driver_setup(msg: DriverSetupRequest) -> RequestUserInput | Se
     if reconfigure:
         _setup_step = SetupSteps.CONFIGURATION_MODE
 
+        # make sure configuration is up-to-date
+        if config.devices.migration_required():
+            await config.devices.migrate()
+
         # get all configured devices for the user to choose from
         dropdown_devices = []
         for device in config.devices.all():

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -160,7 +160,7 @@ class AppleTv:
     @property
     def log_id(self) -> str:
         """Return a log identifier."""
-        return self._device.name
+        return self._device.name if self._device.name else self._device.identifier
 
     @property
     def name(self) -> str:

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -392,6 +392,10 @@ class AppleTv:
             )
 
         _LOG.debug("[%s] Connecting to device", conf.name)
+        # In case the device has been renamed
+        if self._device.name != conf.name:
+            self._device.name = conf.name
+
         self._atv = await pyatv.connect(conf, self._loop)
 
     async def disconnect(self) -> None:


### PR DESCRIPTION
Release 0.13.0 added a new configuration field, which prevented the integration to load old configuration files.
If the new `name` field is missing, automatically scan the device and update the configuration. This is done during startup and also at the start of a reconfiguration, since the network might not yet be available when the integration starts.