### PR TITLE
Release v0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+---
+
+## v0.13.4 - 2024-03-09
 ### Fixed
 - Invalid driver metadata file for the Remote Two ([feature-and-bug-tracker#340](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/340)).
 - Temporary workaround for standby check ([#15](https://github.com/unfoldedcircle/integration-appletv/issues/15)).
-
----
 
 ## v0.13.3 - 2024-03-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 _Changes in the next release_
 
 ### Fixed
-- Invalid driver metadata file for the Remote Two.
+- Invalid driver metadata file for the Remote Two ([feature-and-bug-tracker#340](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/340)).
+- Temporary workaround for standby check ([#15](https://github.com/unfoldedcircle/integration-appletv/issues/15)).
 
 ---
 

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -155,9 +155,14 @@ async def media_player_cmd_handler(
         return ucapi.StatusCodes.SERVICE_UNAVAILABLE
 
     # If the entity is OFF (device is in standby), we turn it on regardless of the actual command
+    # TODO #15 implement proper fix for correct entity OFF state (it may not remain in OFF state if connection is
+    #  established) + online check if we think it is in standby mode.
     if configured_entity.attributes[media_player.Attributes.STATE] == media_player.States.OFF:
         _LOG.debug("Device is off, sending turn on command")
-        return await device.turn_on()
+        # quick & dirty workaround for #15: the entity state is not always correct!
+        res = await device.turn_on()
+        if res != ucapi.StatusCodes.OK:
+            return res
 
     # Only proceed if device connection is established
     if device.is_on is False:


### PR DESCRIPTION
- Invalid driver metadata file for the Remote Two ([feature-and-bug-tracker#340](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/340)).
- Temporary workaround for standby check ([#15](https://github.com/unfoldedcircle/integration-appletv/issues/15)).