### PR TITLE
Stream to output devices through sound mode selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Supported attributes:
 - Artwork
 - Media duration
 - Media position
+- Sound mode (list of output device(s) streamed to)
 
 Supported commands:
 - Turn on & off (device will be put into standby)
@@ -31,6 +32,7 @@ Supported commands:
 - Launch application
 - App switcher
 - Start screensaver
+- Stream audio to one or multiple output devices
 
 Please note that certain commands like channel up & down are app dependant and don't work with every app!
 

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -525,7 +525,7 @@ def _register_available_entities(identifier: str, name: str) -> bool:
                 SimpleCommands.SKIP_FORWARD.value,
                 SimpleCommands.SKIP_BACKWARD.value,
                 SimpleCommands.FAST_FORWARD_BEGIN.value,
-                SimpleCommands.REWIND_BEGIN.value
+                SimpleCommands.REWIND_BEGIN.value,
             ]
         },
         cmd_handler=media_player_cmd_handler,

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -239,7 +239,6 @@ async def media_player_cmd_handler(
             mode = _get_cmd_param("sound_mode", params)
             res = await device.set_output_device(mode)
 
-
             # we wait a bit to get a push update, because music can play in the background
             await asyncio.sleep(1)
             if configured_entity.attributes[media_player.Attributes.STATE] != media_player.States.PLAYING:
@@ -377,7 +376,7 @@ async def on_atv_update(entity_id: str, update: dict[str, Any] | None) -> None:
         and target_entity.attributes.get(media_player.Attributes.MEDIA_DURATION, 0) != update["total_time"]
     ):
         attributes[media_player.Attributes.MEDIA_DURATION] = update["total_time"]
-    if "source" in update and targe - t_entity.attributes.get(media_player.Attributes.SOURCE, "") != update["source"]:
+    if "source" in update and target_entity.attributes.get(media_player.Attributes.SOURCE, "") != update["source"]:
         attributes[media_player.Attributes.SOURCE] = update["source"]
     # end poller update handling
 
@@ -395,6 +394,17 @@ async def on_atv_update(entity_id: str, update: dict[str, Any] | None) -> None:
                 attributes[media_player.Attributes.SOURCE_LIST] = update["sourceList"]
         else:
             attributes[media_player.Attributes.SOURCE_LIST] = update["sourceList"]
+    if (
+        "sound_mode" in update
+        and target_entity.attributes.get(media_player.Attributes.SOUND_MODE, "") != update["sound_mode"]
+    ):
+        attributes[media_player.Attributes.SOUND_MODE] = update["sound_mode"]
+    if "sound_mode_list" in update:
+        if media_player.Attributes.SOUND_MODE_LIST in target_entity.attributes:
+            if len(target_entity.attributes[media_player.Attributes.SOUND_MODE_LIST]) != len(update["sound_mode_list"]):
+                attributes[media_player.Attributes.SOUND_MODE_LIST] = update["sound_mode_list"]
+        else:
+            attributes[media_player.Attributes.SOUND_MODE_LIST] = update["sound_mode_list"]
     if "media_type" in update:
         if update["media_type"] == pyatv.const.MediaType.Music:
             media_type = media_player.MediaType.MUSIC
@@ -497,7 +507,7 @@ def _register_available_entities(identifier: str, name: str) -> bool:
         media_player.Features.MENU,
         media_player.Features.REWIND,
         media_player.Features.FAST_FORWARD,
-        media_player.Features.SELECT_SOUND_MODE
+        media_player.Features.SELECT_SOUND_MODE,
     ]
     if ENABLE_REPEAT_FEAT:
         features.append(media_player.Features.REPEAT)

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -42,6 +42,10 @@ class SimpleCommands(str, Enum):
     """Show running applications."""
     SCREENSAVER = "SCREENSAVER"
     """Run screensaver."""
+    SKIP_FORWARD = "SKIP_FORWARD"
+    """Skip forward a time interval."""
+    SKIP_BACKWARD = "SKIP_BACKWARD"
+    """Skip forward a time interval."""
 
 
 @api.listens_to(ucapi.Events.CONNECT)
@@ -259,6 +263,10 @@ async def media_player_cmd_handler(
             res = await device.app_switcher()
         case SimpleCommands.SCREENSAVER:
             res = await device.screensaver()
+        case SimpleCommands.SKIP_FORWARD:
+            res = await device.skip_forward()
+        case SimpleCommands.SKIP_BACKWARD:
+            res = await device.skip_backward()
 
     return res
 
@@ -506,6 +514,7 @@ def _register_available_entities(identifier: str, name: str) -> bool:
                 SimpleCommands.TOP_MENU.value,
                 SimpleCommands.APP_SWITCHER.value,
                 SimpleCommands.SCREENSAVER.value,
+
             ]
         },
         cmd_handler=media_player_cmd_handler,

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -46,6 +46,10 @@ class SimpleCommands(str, Enum):
     """Skip forward a time interval."""
     SKIP_BACKWARD = "SKIP_BACKWARD"
     """Skip forward a time interval."""
+    FAST_FORWARD_BEGIN = "FAST_FORWARD_BEGIN"
+    """Fast forward using Companion protocol."""
+    REWIND_BEGIN = "REWIND_BEGIN"
+    """Rewind using Companion protocol."""
 
 
 @api.listens_to(ucapi.Events.CONNECT)
@@ -267,6 +271,10 @@ async def media_player_cmd_handler(
             res = await device.skip_forward()
         case SimpleCommands.SKIP_BACKWARD:
             res = await device.skip_backward()
+        case SimpleCommands.FAST_FORWARD_BEGIN:
+            res = await device.fast_forward_companion()
+        case SimpleCommands.REWIND_BEGIN:
+            res = await device.rewind_companion()
 
     return res
 
@@ -514,7 +522,10 @@ def _register_available_entities(identifier: str, name: str) -> bool:
                 SimpleCommands.TOP_MENU.value,
                 SimpleCommands.APP_SWITCHER.value,
                 SimpleCommands.SCREENSAVER.value,
-
+                SimpleCommands.SKIP_FORWARD.value,
+                SimpleCommands.SKIP_BACKWARD.value,
+                SimpleCommands.FAST_FORWARD_BEGIN.value,
+                SimpleCommands.REWIND_BEGIN.value
             ]
         },
         cmd_handler=media_player_cmd_handler,

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -223,7 +223,6 @@ async def media_player_cmd_handler(
             res = await device.rewind()
         case media_player.Commands.FAST_FORWARD:
             res = await device.fast_forward()
-
         case media_player.Commands.REPEAT:
             mode = _get_cmd_param("repeat", params)
             res = await device.set_repeat(mode) if mode else ucapi.StatusCodes.BAD_REQUEST
@@ -234,9 +233,12 @@ async def media_player_cmd_handler(
             res = await device.context_menu()
         case media_player.Commands.MENU:
             res = await device.control_center()
-
         case media_player.Commands.HOME:
             res = await device.home()
+        case media_player.Commands.SELECT_SOUND_MODE:
+            mode = _get_cmd_param("sound_mode", params)
+            res = await device.set_output_device(mode)
+
 
             # we wait a bit to get a push update, because music can play in the background
             await asyncio.sleep(1)
@@ -495,6 +497,7 @@ def _register_available_entities(identifier: str, name: str) -> bool:
         media_player.Features.MENU,
         media_player.Features.REWIND,
         media_player.Features.FAST_FORWARD,
+        media_player.Features.SELECT_SOUND_MODE
     ]
     if ENABLE_REPEAT_FEAT:
         features.append(media_player.Features.REPEAT)

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -235,9 +235,6 @@ async def media_player_cmd_handler(
             res = await device.control_center()
         case media_player.Commands.HOME:
             res = await device.home()
-        case media_player.Commands.SELECT_SOUND_MODE:
-            mode = _get_cmd_param("sound_mode", params)
-            res = await device.set_output_device(mode)
 
             # we wait a bit to get a push update, because music can play in the background
             await asyncio.sleep(1)
@@ -276,6 +273,9 @@ async def media_player_cmd_handler(
             res = await device.fast_forward_companion()
         case SimpleCommands.REWIND_BEGIN:
             res = await device.rewind_companion()
+        case media_player.Commands.SELECT_SOUND_MODE:
+            mode = _get_cmd_param("mode", params)
+            res = await device.set_output_device(mode)
 
     return res
 

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -375,7 +375,7 @@ async def on_atv_update(entity_id: str, update: dict[str, Any] | None) -> None:
         and target_entity.attributes.get(media_player.Attributes.MEDIA_DURATION, 0) != update["total_time"]
     ):
         attributes[media_player.Attributes.MEDIA_DURATION] = update["total_time"]
-    if "source" in update and target_entity.attributes.get(media_player.Attributes.SOURCE, "") != update["source"]:
+    if "source" in update and targe - t_entity.attributes.get(media_player.Attributes.SOURCE, "") != update["source"]:
         attributes[media_player.Attributes.SOURCE] = update["source"]
     # end poller update handling
 

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -31,9 +31,8 @@ from typing import (
 
 import pyatv
 import ucapi
-from pyatv import interface
-
 from config import AtvDevice, AtvProtocol
+from pyatv import interface
 from pyatv.const import (
     DeviceState,
     FeatureName,

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -201,12 +201,12 @@ class AppleTv:
 
     @property
     def output_devices(self) -> [str]:
-        """Return the list of possible selection (combinations) of output devices"""
+        """Return the list of possible selection (combinations) of output devices."""
         return list(self._output_devices.keys())
 
     @property
     def output_device(self) -> str:
-        """Return the current selection of output devices"""
+        """Return the current selection of output devices."""
         device_names = []
         for device in self._output_device:
             device_names.append(device.name)
@@ -572,7 +572,7 @@ class AppleTv:
             self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
 
     def _build_output_devices_list(self, atvs: list[BaseConfig], device_ids: [str]):
-        """Build possible combinations of output devices"""
+        """Build possible combinations of output devices."""
         # Don't go beyond combinations of 5 devices
         max_len = min(len(device_ids), 4)
         for i in range(0, max_len):
@@ -828,7 +828,7 @@ class AppleTv:
 
     @async_handle_atvlib_errors
     async def set_output_device(self, device_name: str) -> ucapi.StatusCodes:
-        """Set output device selection"""
+        """Set output device selection."""
         if device_name is None:
             return ucapi.StatusCodes.BAD_REQUEST
         device_entry = self._output_devices.get(device_name, [])

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -10,6 +10,7 @@ Uses the [pyatv](https://github.com/postlund/pyatv) library with concepts borrow
 
 import asyncio
 import base64
+import itertools
 import logging
 import random
 from asyncio import AbstractEventLoop
@@ -28,12 +29,9 @@ from typing import (
 )
 
 import pyatv
-import pyatv.const
 import ucapi
-from pyatv.interface import OutputDevice
-
 from config import AtvDevice, AtvProtocol
-import itertools
+from pyatv.interface import OutputDevice
 from pyatv.const import (
     DeviceState,
     FeatureName,
@@ -203,10 +201,12 @@ class AppleTv:
 
     @property
     def output_devices(self) -> [str]:
+        """Return the list of possible selection (combinations) of output devices"""
         return list(self._output_devices.keys())
 
     @property
     def output_device(self) -> str:
+        """Return the current selection of output devices"""
         device_names = []
         for device in self._output_device:
             device_names.append(device.name)
@@ -825,6 +825,7 @@ class AppleTv:
 
     @async_handle_atvlib_errors
     async def set_output_device(self, device_name: str) -> ucapi.StatusCodes:
+        """Set output device selection"""
         if device_name is None:
             return ucapi.StatusCodes.BAD_REQUEST
         device_entry = self._output_devices.get(device_name, [])

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -42,7 +42,7 @@ from pyatv.const import (
     ShuffleState,
 )
 from pyatv.core.facade import FacadeRemoteControl
-from pyatv.interface import BaseConfig, OutputDevice
+from pyatv.interface import BaseConfig
 from pyatv.protocols.companion import CompanionAPI, MediaControlCommand, SystemStatus
 from pyee import AsyncIOEventEmitter
 

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -20,6 +20,8 @@ from typing import Any, Awaitable, Callable, Concatenate, Coroutine, ParamSpec, 
 import pyatv
 import pyatv.const
 import ucapi
+from pyatv.core.facade import FacadeRemoteControl
+
 from config import AtvDevice, AtvProtocol
 from pyatv.const import (
     DeviceState,
@@ -580,6 +582,24 @@ class AppleTv:
     async def rewind(self) -> ucapi.StatusCodes:
         """Long press key left for rewind."""
         await self._atv.remote_control.left(InputAction.Hold)
+
+    @async_handle_atvlib_errors
+    async def fast_forward_companion(self) -> ucapi.StatusCodes:
+        """Fast-forward using companion protocol."""
+        companion = cast(FacadeRemoteControl, self._atv.remote_control).get(Protocol.Companion)
+        if companion:
+            await companion.api.mediacontrol_command(command=MediaControlCommand.FastForwardBegin)
+        else:
+            await self._atv.remote_control.right(InputAction.Hold)
+
+    @async_handle_atvlib_errors
+    async def rewind_companion(self) -> ucapi.StatusCodes:
+        """Rewind using companion protocol."""
+        companion = cast(FacadeRemoteControl, self._atv.remote_control).get(Protocol.Companion)
+        if companion:
+            await companion.api.mediacontrol_command(command=MediaControlCommand.RewindBegin)
+        else:
+            await self._atv.remote_control.left(InputAction.Hold)
 
     @async_handle_atvlib_errors
     async def next(self) -> ucapi.StatusCodes:

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -535,6 +535,8 @@ class AppleTv:
 
     async def _update_output_devices(self) -> None:
         _LOG.debug("[%s] Updating available output devices list", self.log_id)
+        if self._atv is None:
+            return
         current_output_devices = self._available_output_devices
         current_output_device = self.output_device
         self._available_output_devices = {}

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -15,7 +15,7 @@ import random
 from asyncio import AbstractEventLoop
 from enum import IntEnum
 from functools import wraps
-from typing import Any, Awaitable, Callable, Concatenate, Coroutine, ParamSpec, TypeVar
+from typing import Any, Awaitable, Callable, Concatenate, Coroutine, ParamSpec, TypeVar, cast
 
 import pyatv
 import pyatv.const
@@ -31,7 +31,7 @@ from pyatv.const import (
     RepeatState,
     ShuffleState,
 )
-from pyatv.protocols.companion import CompanionAPI, SystemStatus
+from pyatv.protocols.companion import CompanionAPI, SystemStatus, CompanionRemoteControl, MediaControlCommand
 from pyee import AsyncIOEventEmitter
 
 _LOG = logging.getLogger(__name__)

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -23,10 +23,10 @@ from typing import (
     Callable,
     Concatenate,
     Coroutine,
+    List,
     ParamSpec,
     TypeVar,
     cast,
-    List,
 )
 
 import pyatv

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -43,7 +43,6 @@ from pyatv.const import (
 from pyatv.core.facade import FacadeRemoteControl
 from pyatv.protocols.companion import (
     CompanionAPI,
-    CompanionRemoteControl,
     MediaControlCommand,
     SystemStatus,
 )

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -41,11 +41,7 @@ from pyatv.const import (
     ShuffleState,
 )
 from pyatv.core.facade import FacadeRemoteControl
-from pyatv.protocols.companion import (
-    CompanionAPI,
-    MediaControlCommand,
-    SystemStatus,
-)
+from pyatv.protocols.companion import CompanionAPI, MediaControlCommand, SystemStatus
 from pyee import AsyncIOEventEmitter
 
 _LOG = logging.getLogger(__name__)

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -837,7 +837,9 @@ class AppleTv:
         device_ids = []
         for device in output_devices:
             device_ids.append(device.identifier)
-        await self._atv.audio.remove_output_devices(device_ids)
+        _LOG.debug("Removing output devices %s", device_ids)
+        await self._atv.audio.remove_output_devices(*device_ids)
         if len(device_entry) == 0:
             return ucapi.StatusCodes.OK
-        await self._atv.audio.set_output_devices(device_entry)
+        _LOG.debug("Setting output devices %s", device_entry)
+        await self._atv.audio.set_output_devices(*device_entry)

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -31,7 +31,6 @@ from typing import (
 import pyatv
 import ucapi
 from config import AtvDevice, AtvProtocol
-from pyatv.interface import OutputDevice, BaseConfig
 from pyatv.const import (
     DeviceState,
     FeatureName,
@@ -43,6 +42,7 @@ from pyatv.const import (
     ShuffleState,
 )
 from pyatv.core.facade import FacadeRemoteControl
+from pyatv.interface import BaseConfig, OutputDevice
 from pyatv.protocols.companion import CompanionAPI, MediaControlCommand, SystemStatus
 from pyee import AsyncIOEventEmitter
 

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -15,13 +15,20 @@ import random
 from asyncio import AbstractEventLoop
 from enum import IntEnum
 from functools import wraps
-from typing import Any, Awaitable, Callable, Concatenate, Coroutine, ParamSpec, TypeVar, cast
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Concatenate,
+    Coroutine,
+    ParamSpec,
+    TypeVar,
+    cast,
+)
 
 import pyatv
 import pyatv.const
 import ucapi
-from pyatv.core.facade import FacadeRemoteControl
-
 from config import AtvDevice, AtvProtocol
 from pyatv.const import (
     DeviceState,
@@ -33,7 +40,13 @@ from pyatv.const import (
     RepeatState,
     ShuffleState,
 )
-from pyatv.protocols.companion import CompanionAPI, SystemStatus, CompanionRemoteControl, MediaControlCommand
+from pyatv.core.facade import FacadeRemoteControl
+from pyatv.protocols.companion import (
+    CompanionAPI,
+    CompanionRemoteControl,
+    MediaControlCommand,
+    SystemStatus,
+)
 from pyee import AsyncIOEventEmitter
 
 _LOG = logging.getLogger(__name__)


### PR DESCRIPTION
This PR lets select one ore several output devices to stream audio to.
How it works : at connection, the list of available output devices are retrieved (airplay compatible)
The through the sound mode selection, a list of possible combinations is displayed :

1. First entry with the name of apple tv : disable all output devices except Apple TV
2. Next entries : list of possible combinations

For example if you have 2 homepods e.g "Homepod 1" and "Homepod 2" you will have :

1. Apple TV
2. Homepod 1 => stream audio to AppleTV + Homepod1
3. Homepod 2 =>  stream audio to AppleTV + Homepod1
4. Homepod 1, Homepod 2  stream audio to AppleTV + Homepod1 + Homepod2

![image](https://github.com/unfoldedcircle/integration-appletv/assets/118518828/a9226695-008c-40d8-b092-a86167fd022f)

The dropdown list should be improved in the webconfigurator because entries are cropped, otherwise it works perfectly.
I guess this is a temporary approach : the list can grow up fastly if you have many airplay devices. I limited the number of items between 1 (1 device enabled) and  5 (5 devices enabled)