### PR TITLE
create a compatible custom integration installation archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - refactor/intg-lib-0.1.3  # FOR TESTING ONLY
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
   pull_request:
@@ -56,7 +55,7 @@ jobs:
             bash -c \
             "cd /workspace && \
               python -m pip install -r requirements.txt && \
-              pyinstaller --clean --onefile --name intg-appletv --collect-all zeroconf intg-appletv/driver.py"
+              pyinstaller --clean --onedir --name intg-appletv --collect-all zeroconf intg-appletv/driver.py"
 
       - name: Add version
         run: |
@@ -67,7 +66,9 @@ jobs:
       - name: Prepare artifacts
         shell: bash
         run: |
-          cp dist/intg-appletv artifacts/
+          mv dist/intg-appletv artifacts/
+          mv artifacts/intg-appletv artifacts/bin
+          mv artifacts/bin/intg-appletv artifacts/bin/driver
           cp driver.json artifacts/
           echo "ARTIFACT_NAME=uc-intg-${{ env.INTG_NAME }}-${{ env.VERSION }}-aarch64" >> $GITHUB_ENV
           

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Changed
+- Create a one-folder bundle with PyInstaller instead a one-file bundle to save resources.
+- Change archive format to the custom integration installation archive.
+- Change default `driver_id` value in `driver.json` to create a compatible custom installation archive.
+
 ---
 
 ## v0.14.0 - 2024-07-09

--- a/README.md
+++ b/README.md
@@ -69,12 +69,18 @@ Otherwise, the `HOME` path is used or the working directory as fallback.
 
 The client name prefix used for pairing can be set in ENV variable `UC_CLIENT_NAME`. The hostname is used by default.
 
-## Build self-contained binary
+## Build distribution binary
 
-After some tests, turns out python stuff on embedded is a nightmare. So we're better off creating a single binary file
-that has everything in it.
+After some tests, turns out Python stuff on embedded is a nightmare. So we're better off creating a binary distribution
+that has everything in it, including the Python runtime and all required modules and native libraries.
 
-To do that, we need to compile it on the target architecture as `pyinstaller` does not support cross compilation.
+To do that, we use [PyInstaller](https://pyinstaller.org/), but it needs to run on the target architecture as
+`PyInstaller` does not support cross compilation.
+
+The `--onefile` option to create a one-file bundled executable should be avoided:
+- Higher startup cost, since the wrapper binary must first extract the archive.
+- Files are extracted to the /tmp directory on the device, which is an in-memory filesystem.  
+  This will further reduce the available memory for the integration drivers!
 
 ### x86-64 Linux
 
@@ -93,7 +99,7 @@ docker run --rm --name builder \
     docker.io/unfoldedcircle/r2-pyinstaller:3.11.6  \
     bash -c \
       "python -m pip install -r requirements.txt && \
-      pyinstaller --clean --onefile --name intg-appletv intg-appletv/driver.py"
+      pyinstaller --clean --onedir --name intg-appletv intg-appletv/driver.py"
 ```
 
 ### aarch64 Linux / Mac
@@ -106,7 +112,7 @@ docker run --rm --name builder \
     docker.io/unfoldedcircle/r2-pyinstaller:3.11.6  \
     bash -c \
       "python -m pip install -r requirements.txt && \
-      pyinstaller --clean --onefile --name intg-appletv intg-appletv/driver.py"
+      pyinstaller --clean --onedir --name intg-appletv intg-appletv/driver.py"
 ```
 
 ## Versioning

--- a/driver.json
+++ b/driver.json
@@ -1,5 +1,5 @@
 {
-	"driver_id": "uc_appletv_driver",
+	"driver_id": "appletv",
 	"version": "0.14.0",
 	"min_core_api": "0.7.0",
 	"name": { "en": "Apple TV" },


### PR DESCRIPTION
- Create a one-folder bundle with PyInstaller instead a one-file bundle to save resources.
- Change archive format to the [custom integration installation archive](https://github.com/unfoldedcircle/core-api/blob/main/doc/integration-driver/driver-installation.md).
- Change default `driver_id` value in `driver.json` to create a compatible custom installation archive.