### PR TITLE
Updated PYATV library, added touch gestures as simple commands, added support for seeking

### DIFF
--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -50,6 +50,14 @@ class SimpleCommands(str, Enum):
     """Fast forward using Companion protocol."""
     REWIND_BEGIN = "REWIND_BEGIN"
     """Rewind using Companion protocol."""
+    SWIPE_LEFT = "SWIPE_LEFT"
+    """Swipe left using Companion protocol."""
+    SWIPE_RIGHT = "SWIPE_RIGHT"
+    """Swipe right using Companion protocol."""
+    SWIPE_UP = "SWIPE_UP"
+    """Swipe up using Companion protocol."""
+    SWIPE_DOWN = "SWIPE_DOWN"
+    """Swipe down using Companion protocol."""
 
 
 @api.listens_to(ucapi.Events.CONNECT)
@@ -276,6 +284,16 @@ async def media_player_cmd_handler(
         case media_player.Commands.SELECT_SOUND_MODE:
             mode = _get_cmd_param("mode", params)
             res = await device.set_output_device(mode)
+        case media_player.Commands.SEEK:
+            res = await device.set_media_position(params.get("media_position", 0))
+        case SimpleCommands.SWIPE_LEFT:
+            res = await device.swipe(1000, 500, 50, 500, 200)
+        case SimpleCommands.SWIPE_RIGHT:
+            res = await device.swipe(50, 500, 1000, 500, 200)
+        case SimpleCommands.SWIPE_UP:
+            res = await device.swipe(500, 1000, 500, 50, 200)
+        case SimpleCommands.SWIPE_DOWN:
+            res = await device.swipe(500, 50, 500, 1000, 200)
 
     return res
 
@@ -508,6 +526,7 @@ def _register_available_entities(identifier: str, name: str) -> bool:
         media_player.Features.REWIND,
         media_player.Features.FAST_FORWARD,
         media_player.Features.SELECT_SOUND_MODE,
+        media_player.Features.SEEK,
     ]
     if ENABLE_REPEAT_FEAT:
         features.append(media_player.Features.REPEAT)
@@ -539,6 +558,10 @@ def _register_available_entities(identifier: str, name: str) -> bool:
                 SimpleCommands.SKIP_BACKWARD.value,
                 SimpleCommands.FAST_FORWARD_BEGIN.value,
                 SimpleCommands.REWIND_BEGIN.value,
+                SimpleCommands.SWIPE_LEFT.value,
+                SimpleCommands.SWIPE_RIGHT.value,
+                SimpleCommands.SWIPE_UP.value,
+                SimpleCommands.SWIPE_DOWN.value,
             ]
         },
         cmd_handler=media_player_cmd_handler,

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -44,10 +44,10 @@ from pyatv.const import (
     RepeatState,
     ShuffleState,
 )
-from pyatv.core.facade import FacadeRemoteControl
+from pyatv.core.facade import FacadeRemoteControl, FacadeTouchGestures
 from pyatv.interface import BaseConfig, OutputDevice
 from pyatv.protocols.companion import CompanionAPI, MediaControlCommand, SystemStatus
-from pyee import AsyncIOEventEmitter
+from pyee.asyncio import AsyncIOEventEmitter
 
 _LOG = logging.getLogger(__name__)
 
@@ -899,3 +899,17 @@ class AppleTv(interface.AudioListener):
             return ucapi.StatusCodes.OK
         _LOG.debug("Setting output devices %s", device_entry)
         await self._atv.audio.set_output_devices(*device_entry)
+
+    @async_handle_atvlib_errors
+    async def set_media_position(self, media_position: int) -> ucapi.StatusCodes:
+        """Set media position."""
+        await self._atv.remote_control.set_position(media_position)
+
+    @async_handle_atvlib_errors
+    async def swipe(self, start_x: int, start_y: int, end_x: int, end_y: int, duration_ms: int) -> ucapi.StatusCodes:
+        """Generate a swipe gesture."""
+        touch_facade: FacadeTouchGestures = cast(FacadeTouchGestures, self._atv.touch)
+        if touch_facade.get(Protocol.Companion):
+            await cast(FacadeTouchGestures, self._atv.touch).swipe(start_x, start_y, end_x, end_y, duration_ms)
+        else:
+            raise ucapi.StatusCodes.NOT_IMPLEMENTED

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -912,4 +912,4 @@ class AppleTv(interface.AudioListener):
         if touch_facade.get(Protocol.Companion):
             await cast(FacadeTouchGestures, self._atv.touch).swipe(start_x, start_y, end_x, end_y, duration_ms)
         else:
-            raise ucapi.StatusCodes.NOT_IMPLEMENTED
+            raise pyatv.exceptions.CommandError("Touch gestures not supported")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyatv==0.14.5
-pyee>=9.0
-ucapi==0.1.7
+pyatv==0.15.1
+pyee~=12.0.0
+ucapi==0.2.0


### PR DESCRIPTION
Following the updates I pushed to pyatv library, I added touch gestures to the integration as simple commands for now.
Later we can consider using the slider of remote 3 for swiping left/right, or maybe a real touch screen if planned on the remote.
Tested ok on my remote.

I also added seeking support which is already handled by all the registered protocols