### PR TITLE
Fixed bug with AppleTV multiple sound output : the current AppleTV de…

### DIFF
--- a/driver.json
+++ b/driver.json
@@ -1,6 +1,6 @@
 {
 	"driver_id": "appletv",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"min_core_api": "0.7.0",
 	"name": { "en": "Apple TV" },
 	"icon": "uc:integration",
@@ -41,5 +41,5 @@
 			}
 		]
 	},
-	"release_date": "2024-09-27"
+	"release_date": "2024-11-03"
 }


### PR DESCRIPTION
Hi Markus @zehnm,

I have fixed a bug with the sound outputs feature : the previous implementation disabled the current AppleTV device when selecting a given combination

This is fixed and tested on my side : now when selecting any combination, it will keep current AppleTV sound output active in addition of other selected devices