### PR TITLE
Another PR to fix deprecation on initialization of event loop

### DIFF
--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -23,7 +23,7 @@ import ucapi.api as uc
 from ucapi import MediaPlayer, media_player
 
 _LOG = logging.getLogger("driver")  # avoid having __main__ in log messages
-if sys.platform == 'win32':
+if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 _LOOP = asyncio.new_event_loop()
 asyncio.set_event_loop(_LOOP)

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -9,6 +9,7 @@ This module implements a Remote Two integration driver for Apple TV devices.
 import asyncio
 import logging
 import os
+import sys
 from enum import Enum
 from typing import Any
 
@@ -22,7 +23,10 @@ import ucapi.api as uc
 from ucapi import MediaPlayer, media_player
 
 _LOG = logging.getLogger("driver")  # avoid having __main__ in log messages
-_LOOP = asyncio.get_event_loop()
+if sys.platform == 'win32':
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+_LOOP = asyncio.new_event_loop()
+asyncio.set_event_loop(_LOOP)
 
 # Global variables
 api = uc.IntegrationAPI(_LOOP)


### PR DESCRIPTION
This modification should be applied to all Python integrations
Event loop was previously created by calling `get_event_loop` method.
Now it should be explicitly created by calling `new_event_loop`

I also added an optional block to make the integration compatible with windows for testing purpose. This can be removed 