### PR TITLE
Fixed unavailable device/driver after AppleTV device going off

### DIFF
--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -181,14 +181,13 @@ async def media_player_cmd_handler(
         return ucapi.StatusCodes.SERVICE_UNAVAILABLE
 
     # If the entity is OFF (device is in standby), we turn it on regardless of the actual command
+    if device.is_on is None or device.is_on is False:
+        _LOG.debug("Device not connected, reconnect")
+        await device.connect()
+
     # TODO #15 implement proper fix for correct entity OFF state (it may not remain in OFF state if connection is
     #  established) + online check if we think it is in standby mode.
-    if device.is_on is False and cmd_id != media_player.Commands.OFF:
-        await device.connect()
-        res = await device.turn_on()
-        if res != ucapi.StatusCodes.OK:
-            return res
-    elif (
+    if (
         configured_entity.attributes[media_player.Attributes.STATE] == media_player.States.OFF
         and cmd_id != media_player.Commands.OFF
     ):

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -154,7 +154,7 @@ async def on_unsubscribe_entities(entity_ids: list[str]) -> None:
             device.events.remove_all_listeners()
 
 
-# pylint: disable=too-many-statements
+# pylint: disable=too-many-statements,too-many-return-statements
 async def media_player_cmd_handler(
     entity: MediaPlayer, cmd_id: str, params: dict[str, Any] | None
 ) -> ucapi.StatusCodes:
@@ -183,7 +183,6 @@ async def media_player_cmd_handler(
     # If the entity is OFF (device is in standby), we turn it on regardless of the actual command
     # TODO #15 implement proper fix for correct entity OFF state (it may not remain in OFF state if connection is
     #  established) + online check if we think it is in standby mode.
-    # pylint: disable=R0911
     if device.is_on is False and cmd_id != media_player.Commands.OFF:
         await device.connect()
         res = await device.turn_on()

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -338,7 +338,7 @@ async def on_atv_disconnected(identifier: str) -> None:
     """Handle ATV disconnection."""
     _LOG.debug("Apple TV disconnected: %s", identifier)
     api.configured_entities.update_attributes(
-        identifier, {media_player.Attributes.STATE: media_player.States.UNAVAILABLE}
+        identifier, {media_player.Attributes.STATE: media_player.States.OFF}
     )
 
 

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -183,6 +183,7 @@ async def media_player_cmd_handler(
     # If the entity is OFF (device is in standby), we turn it on regardless of the actual command
     # TODO #15 implement proper fix for correct entity OFF state (it may not remain in OFF state if connection is
     #  established) + online check if we think it is in standby mode.
+    # pylint: disable=R0911
     if device.is_on is False and cmd_id != media_player.Commands.OFF:
         await device.connect()
         res = await device.turn_on()

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -183,10 +183,7 @@ async def media_player_cmd_handler(
     # If the entity is OFF (device is in standby), we turn it on regardless of the actual command
     # TODO #15 implement proper fix for correct entity OFF state (it may not remain in OFF state if connection is
     #  established) + online check if we think it is in standby mode.
-    if (
-            device.is_on is False
-            and cmd_id != media_player.Commands.OFF
-    ):
+    if device.is_on is False and cmd_id != media_player.Commands.OFF:
         await device.connect()
         res = await device.turn_on()
         if res != ucapi.StatusCodes.OK:

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -184,6 +184,14 @@ async def media_player_cmd_handler(
     # TODO #15 implement proper fix for correct entity OFF state (it may not remain in OFF state if connection is
     #  established) + online check if we think it is in standby mode.
     if (
+            device.is_on is False
+            and cmd_id != media_player.Commands.OFF
+    ):
+        await device.connect()
+        res = await device.turn_on()
+        if res != ucapi.StatusCodes.OK:
+            return res
+    elif (
         configured_entity.attributes[media_player.Attributes.STATE] == media_player.States.OFF
         and cmd_id != media_player.Commands.OFF
     ):

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -337,9 +337,7 @@ async def on_atv_connected(identifier: str) -> None:
 async def on_atv_disconnected(identifier: str) -> None:
     """Handle ATV disconnection."""
     _LOG.debug("Apple TV disconnected: %s", identifier)
-    api.configured_entities.update_attributes(
-        identifier, {media_player.Attributes.STATE: media_player.States.OFF}
-    )
+    api.configured_entities.update_attributes(identifier, {media_player.Attributes.STATE: media_player.States.OFF})
 
 
 async def on_atv_connection_error(identifier: str, message) -> None:

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -341,7 +341,9 @@ async def on_atv_connected(identifier: str) -> None:
 async def on_atv_disconnected(identifier: str) -> None:
     """Handle ATV disconnection."""
     _LOG.debug("Apple TV disconnected: %s", identifier)
-    api.configured_entities.update_attributes(identifier, {media_player.Attributes.STATE: media_player.States.OFF})
+    api.configured_entities.update_attributes(
+        identifier, {media_player.Attributes.STATE: media_player.States.UNAVAILABLE}
+    )
 
 
 async def on_atv_connection_error(identifier: str, message) -> None:

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -264,7 +264,6 @@ class AppleTv(interface.AudioListener):
         if self._atv:
             self._atv.close()
             self._atv = None
-        # self.events.emit(EVENTS.DISCONNECTED, self._device.identifier)
         self._start_connect_loop()
 
     def volume_update(self, _old_level: float, new_level: float) -> None:
@@ -450,7 +449,6 @@ class AppleTv(interface.AudioListener):
                 self._atv.close()
             if self._connect_task:
                 self._connect_task.cancel()
-            # self.events.emit(EVENTS.DISCONNECTED, self._device.identifier)
         except Exception as err:  # pylint: disable=broad-exception-caught
             _LOG.exception("[%s] An error occurred while disconnecting: %s", self.log_id, err)
         finally:

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -264,7 +264,7 @@ class AppleTv(interface.AudioListener):
         if self._atv:
             self._atv.close()
             self._atv = None
-        self.events.emit(EVENTS.DISCONNECTED, self._device.identifier)
+        # self.events.emit(EVENTS.DISCONNECTED, self._device.identifier)
         self._start_connect_loop()
 
     def volume_update(self, _old_level: float, new_level: float) -> None:
@@ -450,7 +450,7 @@ class AppleTv(interface.AudioListener):
                 self._atv.close()
             if self._connect_task:
                 self._connect_task.cancel()
-            self.events.emit(EVENTS.DISCONNECTED, self._device.identifier)
+            # self.events.emit(EVENTS.DISCONNECTED, self._device.identifier)
         except Exception as err:  # pylint: disable=broad-exception-caught
             _LOG.exception("[%s] An error occurred while disconnecting: %s", self.log_id, err)
         finally:

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -100,7 +100,10 @@ def async_handle_atvlib_errors(
     async def wrapper(self: _AppleTvT, *args: _P.args, **kwargs: _P.kwargs) -> ucapi.StatusCodes:
         # pylint: disable=protected-access
         if self._atv is None:
-            return ucapi.StatusCodes.SERVICE_UNAVAILABLE
+            _LOG.debug("Command wrapper : not connected try reconnect")
+            await self.connect()
+            if self._atv is None:
+                return ucapi.StatusCodes.SERVICE_UNAVAILABLE
 
         result = ucapi.StatusCodes.SERVER_ERROR
         try:


### PR DESCRIPTION
When using AppleTV integration as external, when the device is turned off, the driver reports the entity as "UNAVAILABLE"
But this state makes the driver also unavailable and no request will be done after that between the remote and the driver.
Therefore, no commands are processed from remote side (service unavailable error), the only way to resolve it is to reboot the remote or restart the driver.

This is not a problem I guess if used as internal as you shutdown the driver when it is not used and restart it when used again.

Replacing the reported state by OFF instead of UNAVAILABLE fixes the problem