### PR TITLE
Mute toggle, stop, play, pause commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Added
+- New commands: mute toggle, play, pause, stop ([#34](https://github.com/unfoldedcircle/integration-appletv/issues/34)).
+
 ---
 
 ## v0.16.0 - 2025-03-24

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Supported commands:
 - Volume up / down
 - Mute toggle
 - Play/pause
+- Stop, play, pause
 - Directional pad navigation and select
 - Context menu
 - Home screen

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Apple TV integration for Remote Two/3
 
-Using [pyatv](https://github.com/postlund/pyatv) and [uc-integration-api](https://github.com/aitatoi/integration-python-library)
+This integration is based on the great [pyatv](https://github.com/postlund/pyatv) library and uses our
+[uc-integration-api](https://github.com/aitatoi/integration-python-library) to communicate with the Remote Two/3.
 
 The driver discovers Apple TV devices on the network and pairs them using AirPlay and companion protocols.
 A [media player entity](https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/entity_media_player.md)
 is exposed to the Remote Two/3.
 
 Supported versions:
-- Apple TV 4 and newer models with TvOS 16+
+- Apple TV 4 and newer models with tvOS 16+
 
 Supported attributes:
 - State (on, off, playing, paused, unknown)
@@ -24,6 +25,7 @@ Supported commands:
 - Next / Previous
 - Rewind / Fast-forward
 - Volume up / down
+- Mute toggle
 - Play/pause
 - Directional pad navigation and select
 - Context menu
@@ -34,9 +36,39 @@ Supported commands:
 - Start screensaver
 - Stream audio to one or multiple output devices
 
-Please note that certain commands like channel up & down are app dependant and don't work with every app!
+Please note:
+- Certain commands like channel up & down are app dependant and don't work with every app!
+- Media information and artwork are not provided by every app.
+
+## Requirements
+
+Please also check the [pyatv troubleshooting](https://pyatv.dev/support/troubleshooting/) section for more information.
+
+If you have trouble using this integration with your Apple TV, then please open an issue with us and not the 3rd party
+[pyatv](https://github.com/postlund/pyatv) library! Unless of course you are a developer and can track down a specific
+issue in the library with all the required information to reproduce it.
+
+### Network
+
+- The Apple TV device must be on the same network subnet as the Remote. Routed networks are not supported.
+- [Zeroconf](https://en.m.wikipedia.org/wiki/Zero-configuration_networking) (multicast DNS) must be a allowed.  
+  Check your WiFi access point and router that this traffic is not filtered out.
+- When using DHCP: a static IP address reservation for the Apple TV device(s) is recommended.  
+  This speeds up reconnection and helps to identify the device again if Apple changes the (not so) unique device identifiers. 
+
+### Apple TV device
+
+- Make sure you have  _"Allow Access"_ set to _"Anyone on the Same Network"_ for AirPlay on your Apple TV.
+- When using multiple Apple TVs, each device should have a unique name for easier identification.  
+  - The name can be set under Settings, General, About: Name  
+- The name should not be changed anymore once the Apple TV is connected with this integration.  
+  This helps to identify the device again if the device identifiers change after a tvOS update.
+- Disabling automatic software updates is recommended, especially if you rely on controlling an Apple TV with an Unfolded Circle Remote.
+  - tvOS updates might break certain functionality.
+  - It can take time to fix these issues and release a new integration version.
 
 ## Usage
+
 ### Setup
 
 - Requires Python 3.11

--- a/driver.json
+++ b/driver.json
@@ -2,14 +2,6 @@
 	"driver_id": "appletv",
 	"version": "0.16.0",
 	"min_core_api": "0.7.0",
-	"requirements": {
-		"min_core_api": "",
-		"max_core_api": "",
-		"min_integration_api": "",
-		"max_integration_api": "",
-		"min_firmware": "",
-		"max_firmware": ""
-	},
 	"name": { "en": "Apple TV" },
 	"icon": "uc:integration",
 	"description": {

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -126,7 +126,6 @@ async def on_subscribe_entities(entity_ids: list[str]) -> None:
     """
     _LOG.debug("Subscribe entities event: %s", entity_ids)
     for entity_id in entity_ids:
-        # TODO #11 add atv_id -> list(entities_id) mapping. Right now the atv_id == entity_id!
         atv_id = entity_id
         if atv_id in _configured_atvs:
             atv = _configured_atvs[atv_id]
@@ -150,7 +149,6 @@ async def on_subscribe_entities(entity_ids: list[str]) -> None:
 async def on_unsubscribe_entities(entity_ids: list[str]) -> None:
     """On unsubscribe, we disconnect the objects and remove listeners for events."""
     _LOG.debug("Unsubscribe entities event: %s", entity_ids)
-    # TODO #11 add entity_id --> atv_id mapping. Right now the atv_id == entity_id!
     for entity_id in entity_ids:
         if entity_id in _configured_atvs:
             device = _configured_atvs.pop(entity_id)
@@ -175,7 +173,6 @@ async def media_player_cmd_handler(
     """
     _LOG.info("Got %s command request: %s %s", entity.id, cmd_id, params if params else "")
 
-    # TODO #11 map from device id to entities (see Denon integration)
     atv_id = entity.id
     device = _configured_atvs[atv_id]
 
@@ -532,7 +529,6 @@ def _register_available_entities(identifier: str, name: str) -> bool:
     :param name: Friendly name
     :return: True if added, False if the device was already in storage.
     """
-    # TODO #11 map entity IDs from device identifier
     entity_id = identifier
     # plain and simple for now: only one media_player per ATV device
     features = [
@@ -631,7 +627,6 @@ def on_device_removed(device: config.AtvDevice | None) -> None:
             atv = _configured_atvs.pop(device.identifier)
             _LOOP.create_task(atv.disconnect())
             atv.events.remove_all_listeners()
-            # TODO #11 map entity IDs from device identifier
             entity_id = atv.identifier
             api.configured_entities.remove(entity_id)
             api.available_entities.remove(entity_id)
@@ -684,8 +679,6 @@ async def main():
     # best effort migration (if required): network might not be available during startup
     await config.devices.migrate()
 
-    # TODO REMOVE COMMENT : check with Markus. This check can take (too much) time if the user expects the remote
-    # to be quickly active. I have chosen to launch it in background. Good or bad idea (concurrent write ?)
     # Check for devices changes and update its mac address and ip address if necessary
     await asyncio.create_task(config.devices.handle_devices_change())
     # and register them as available devices.

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -234,6 +234,8 @@ async def media_player_cmd_handler(
             res = await device.volume_up()
         case media_player.Commands.VOLUME_DOWN:
             res = await device.volume_down()
+        case media_player.Commands.MUTE_TOGGLE:
+            res = await device.mute_toggle()
         case media_player.Commands.ON:
             res = await device.turn_on()
         case media_player.Commands.OFF:
@@ -527,7 +529,7 @@ def _register_available_entities(identifier: str, name: str) -> bool:
         media_player.Features.ON_OFF,
         media_player.Features.VOLUME,
         media_player.Features.VOLUME_UP_DOWN,
-        # media_player.Features.MUTE_TOGGLE,
+        media_player.Features.MUTE_TOGGLE,
         media_player.Features.PLAY_PAUSE,
         media_player.Features.NEXT,
         media_player.Features.PREVIOUS,
@@ -561,6 +563,7 @@ def _register_available_entities(identifier: str, name: str) -> bool:
         {
             media_player.Attributes.STATE: media_player.States.UNAVAILABLE,
             media_player.Attributes.VOLUME: 0,
+            # TODO(#34) is there a way to find out if the device is muted?
             # media_player.Attributes.MUTED: False,
             media_player.Attributes.MEDIA_DURATION: 0,
             media_player.Attributes.MEDIA_POSITION: 0,

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -69,6 +69,10 @@ class SimpleCommands(str, Enum):
     """Swipe up using Companion protocol."""
     SWIPE_DOWN = "SWIPE_DOWN"
     """Swipe down using Companion protocol."""
+    PLAY = "PLAY"
+    """Send play command. App specific! Some treat it as play_pause."""
+    PAUSE = "PAUSE"
+    """Send pause command. App specific! Some treat it as play_pause."""
 
 
 @api.listens_to(ucapi.Events.CONNECT)
@@ -226,6 +230,8 @@ async def media_player_cmd_handler(
             except Exception:
                 pass
             res = await device.play_pause()
+        case media_player.Commands.STOP:
+            res = await device.stop()
         case media_player.Commands.NEXT:
             res = await device.next()
         case media_player.Commands.PREVIOUS:
@@ -317,6 +323,10 @@ async def media_player_cmd_handler(
             res = await device.swipe(500, 1000, 500, 50, 200)
         case SimpleCommands.SWIPE_DOWN:
             res = await device.swipe(500, 50, 500, 1000, 200)
+        case SimpleCommands.PLAY:
+            res = await device.play()
+        case SimpleCommands.PAUSE:
+            res = await device.pause()
 
     return res
 
@@ -531,6 +541,7 @@ def _register_available_entities(identifier: str, name: str) -> bool:
         media_player.Features.VOLUME_UP_DOWN,
         media_player.Features.MUTE_TOGGLE,
         media_player.Features.PLAY_PAUSE,
+        media_player.Features.STOP,
         media_player.Features.NEXT,
         media_player.Features.PREVIOUS,
         media_player.Features.MEDIA_DURATION,
@@ -586,6 +597,8 @@ def _register_available_entities(identifier: str, name: str) -> bool:
                 SimpleCommands.SWIPE_RIGHT.value,
                 SimpleCommands.SWIPE_UP.value,
                 SimpleCommands.SWIPE_DOWN.value,
+                SimpleCommands.PLAY.value,
+                SimpleCommands.PAUSE.value,
             ]
         },
         cmd_handler=media_player_cmd_handler,

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -47,6 +47,7 @@ from pyatv.const import (
 from pyatv.core.facade import FacadeRemoteControl, FacadeTouchGestures
 from pyatv.interface import BaseConfig, OutputDevice
 from pyatv.protocols.companion import CompanionAPI, MediaControlCommand, SystemStatus
+from pyatv.protocols.mrp import MrpRemoteControl, messages
 from pyee.asyncio import AsyncIOEventEmitter
 
 _LOG = logging.getLogger(__name__)
@@ -799,6 +800,11 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         await self._atv.audio.volume_down()
 
     @async_handle_atvlib_errors
+    async def mute_toggle(self) -> ucapi.StatusCodes:
+        """Press key mute toggle."""
+        await self._send_hid_key(12, 0xE2)
+
+    @async_handle_atvlib_errors
     async def cursor_up(self) -> ucapi.StatusCodes:
         """Press key up."""
         await self._atv.remote_control.up()
@@ -939,3 +945,15 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             await cast(FacadeTouchGestures, self._atv.touch).swipe(start_x, start_y, end_x, end_y, duration_ms)
         else:
             raise pyatv.exceptions.CommandError("Touch gestures not supported")
+
+    async def _send_hid_key(self, use_page: int, usage: int) -> None:
+        """Send a short HID key press.
+
+        :param use_page: HID usage page (1 Generic Desktop, 7 Keyboard, 12 Consumer)
+        :param usage: HID key usage
+        """
+        if self._atv and isinstance(self._atv.remote_control.main_instance, MrpRemoteControl):
+            await self._atv.remote_control.main_instance.protocol.send(messages.send_hid_event(use_page, usage, True))
+            await self._atv.remote_control.main_instance.protocol.send(messages.send_hid_event(use_page, usage, False))
+        else:
+            _LOG.warning("[%s] send HID key not supported (%d, %d)", self.log_id, use_page, usage)

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -289,7 +289,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         atvs = await pyatv.scan(self._loop, identifier=identifier, hosts=hosts)
         if not atvs:
             return None
-        _LOG.debug(f"Found {len(atvs)} AppleTV for identifier {identifier} and hosts {hosts} : %s")
+        _LOG.debug(f"Found {len(atvs)} AppleTV for identifier {identifier} and hosts {hosts} : %s", atvs[0])
         return atvs[0]
 
     def add_credentials(self, credentials: dict[AtvProtocol, str]) -> None:
@@ -673,6 +673,24 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         """Toggle between play and pause."""
         await self.stop_fast_forward_rewind()
         await self._atv.remote_control.play_pause()
+
+    @async_handle_atvlib_errors
+    async def play(self) -> ucapi.StatusCodes:
+        """Start playback."""
+        await self.stop_fast_forward_rewind()
+        await self._atv.remote_control.play()
+
+    @async_handle_atvlib_errors
+    async def pause(self) -> ucapi.StatusCodes:
+        """Pause playback."""
+        await self.stop_fast_forward_rewind()
+        await self._atv.remote_control.pause()
+
+    @async_handle_atvlib_errors
+    async def stop(self) -> ucapi.StatusCodes:
+        """Stop playback."""
+        await self.stop_fast_forward_rewind()
+        await self._atv.remote_control.stop()
 
     @async_handle_atvlib_errors
     async def fast_forward(self) -> ucapi.StatusCodes:


### PR DESCRIPTION
Add the long missing mute toggle command.
There is no mute functionality exposed in the pyatv APIs (https://github.com/postlund/pyatv/issues/2555). Using the current volume and restoring it to simulate mute also doesn't work (https://github.com/postlund/pyatv/issues/2524).

The internal MRP `_send_hid_key` function is used to send the HID consumer usage code `0xE2`.

Tested on Apple TV 4 HD and 4k.

The stop media-player command is now available too, plus PLAY and PAUSE as simple commands.