### PR TITLE
Alternative play/pause command by sending HID key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 _Changes in the next release_
 
 ### Added
-- New commands: mute toggle, play, pause, stop ([#34](https://github.com/unfoldedcircle/integration-appletv/issues/34)).
+- New commands: mute toggle, stop. New simple commands: PLAY, PAUSE ([#34](https://github.com/unfoldedcircle/integration-appletv/issues/34)).
+- PLAY_PAUSE_KEY test command for alternative play / pause handling by sending a HID key ([feature-and-bug-tracker#159](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/159)).
 
 ---
 

--- a/intg-appletv/hid/__init__.py
+++ b/intg-appletv/hid/__init__.py
@@ -1,0 +1,19 @@
+"""
+HID usage tables.
+
+:copyright: (c) 2025 by Unfolded Circle ApS.
+:license: MPL-2.0, see LICENSE for more details.
+"""
+
+from enum import Enum
+
+
+class UsagePage(int, Enum):
+    """HID usage pages.
+
+    More information: https://www.usb.org/sites/default/files/hut1_6.pdf
+    """
+
+    GENERIC_DESKTOP = 0x01
+    KEYBOARD = 0x07
+    CONSUMER = 0x0C

--- a/intg-appletv/hid/consumer_control_code.py
+++ b/intg-appletv/hid/consumer_control_code.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2018 Dan Halbert for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+# Original source: https://github.com/adafruit/Adafruit_CircuitPython_HID/tree/main
+
+"""
+`adafruit_hid.consumer_control_code.ConsumerControlCode`
+========================================================
+
+* Author(s): Dan Halbert
+"""
+
+
+class ConsumerControlCode:
+    """USB HID Consumer Control Device constants.
+
+    This list includes a few common consumer control codes from
+    https://www.usb.org/sites/default/files/hut1_21_0.pdf#page=118.
+    """
+
+    # pylint: disable-msg=too-few-public-methods
+
+    RECORD = 0xB2
+    """Record"""
+    FAST_FORWARD = 0xB3
+    """Fast Forward"""
+    REWIND = 0xB4
+    """Rewind"""
+    SCAN_NEXT_TRACK = 0xB5
+    """Skip to next track"""
+    SCAN_PREVIOUS_TRACK = 0xB6
+    """Go back to previous track"""
+    STOP = 0xB7
+    """Stop"""
+    EJECT = 0xB8
+    """Eject"""
+    PLAY_PAUSE = 0xCD
+    """Play/Pause toggle"""
+    MUTE = 0xE2
+    """Mute"""
+    VOLUME_DECREMENT = 0xEA
+    """Decrease volume"""
+    VOLUME_INCREMENT = 0xE9
+    """Increase volume"""
+    BRIGHTNESS_DECREMENT = 0x70
+    """Decrease Brightness"""
+    BRIGHTNESS_INCREMENT = 0x6F
+    """Increase Brightness"""

--- a/intg-appletv/hid/keycode.py
+++ b/intg-appletv/hid/keycode.py
@@ -1,0 +1,308 @@
+# SPDX-FileCopyrightText: 2017 Scott Shawcroft for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+# Original source: https://github.com/adafruit/Adafruit_CircuitPython_HID/tree/main
+
+"""
+`adafruit_hid.keycode.Keycode`
+====================================================
+
+* Author(s): Scott Shawcroft, Dan Halbert
+"""
+
+
+class Keycode:
+    """USB HID Keycode constants.
+
+    This list is modeled after the names for USB keycodes defined in
+    https://usb.org/sites/default/files/hut1_21_0.pdf#page=83.
+    This list does not include every single code, but does include all the keys on
+    a regular PC or Mac keyboard.
+
+    Remember that keycodes are the names for key *positions* on a US keyboard, and may
+    not correspond to the character that you mean to send if you want to emulate non-US keyboard.
+    For instance, on a French keyboard (AZERTY instead of QWERTY),
+    the keycode for 'q' is used to indicate an 'a'. Likewise, 'y' represents 'z' on
+    a German keyboard. This is historical: the idea was that the keycaps could be changed
+    without changing the keycodes sent, so that different firmware was not needed for
+    different variations of a keyboard.
+    """
+
+    # pylint: disable-msg=too-few-public-methods
+
+    # pylint: disable-msg=invalid-name
+    A = 0x04
+    """``a`` and ``A``"""
+    B = 0x05
+    """``b`` and ``B``"""
+    C = 0x06
+    """``c`` and ``C``"""
+    D = 0x07
+    """``d`` and ``D``"""
+    E = 0x08
+    """``e`` and ``E``"""
+    F = 0x09
+    """``f`` and ``F``"""
+    G = 0x0A
+    """``g`` and ``G``"""
+    H = 0x0B
+    """``h`` and ``H``"""
+    I = 0x0C
+    """``i`` and ``I``"""
+    J = 0x0D
+    """``j`` and ``J``"""
+    K = 0x0E
+    """``k`` and ``K``"""
+    L = 0x0F
+    """``l`` and ``L``"""
+    M = 0x10
+    """``m`` and ``M``"""
+    N = 0x11
+    """``n`` and ``N``"""
+    O = 0x12
+    """``o`` and ``O``"""
+    P = 0x13
+    """``p`` and ``P``"""
+    Q = 0x14
+    """``q`` and ``Q``"""
+    R = 0x15
+    """``r`` and ``R``"""
+    S = 0x16
+    """``s`` and ``S``"""
+    T = 0x17
+    """``t`` and ``T``"""
+    U = 0x18
+    """``u`` and ``U``"""
+    V = 0x19
+    """``v`` and ``V``"""
+    W = 0x1A
+    """``w`` and ``W``"""
+    X = 0x1B
+    """``x`` and ``X``"""
+    Y = 0x1C
+    """``y`` and ``Y``"""
+    Z = 0x1D
+    """``z`` and ``Z``"""
+
+    ONE = 0x1E
+    """``1`` and ``!``"""
+    TWO = 0x1F
+    """``2`` and ``@``"""
+    THREE = 0x20
+    """``3`` and ``#``"""
+    FOUR = 0x21
+    """``4`` and ``$``"""
+    FIVE = 0x22
+    """``5`` and ``%``"""
+    SIX = 0x23
+    """``6`` and ``^``"""
+    SEVEN = 0x24
+    """``7`` and ``&``"""
+    EIGHT = 0x25
+    """``8`` and ``*``"""
+    NINE = 0x26
+    """``9`` and ``(``"""
+    ZERO = 0x27
+    """``0`` and ``)``"""
+    ENTER = 0x28
+    """Enter (Return)"""
+    RETURN = ENTER
+    """Alias for ``ENTER``"""
+    ESCAPE = 0x29
+    """Escape"""
+    BACKSPACE = 0x2A
+    """Delete backward (Backspace)"""
+    TAB = 0x2B
+    """Tab and Backtab"""
+    SPACEBAR = 0x2C
+    """Spacebar"""
+    SPACE = SPACEBAR
+    """Alias for SPACEBAR"""
+    MINUS = 0x2D
+    """``-` and ``_``"""
+    EQUALS = 0x2E
+    """``=` and ``+``"""
+    LEFT_BRACKET = 0x2F
+    """``[`` and ``{``"""
+    RIGHT_BRACKET = 0x30
+    """``]`` and ``}``"""
+    BACKSLASH = 0x31
+    r"""``\`` and ``|``"""
+    POUND = 0x32
+    """``#`` and ``~`` (Non-US keyboard)"""
+    SEMICOLON = 0x33
+    """``;`` and ``:``"""
+    QUOTE = 0x34
+    """``'`` and ``"``"""
+    GRAVE_ACCENT = 0x35
+    r""":literal:`\`` and ``~``"""
+    COMMA = 0x36
+    """``,`` and ``<``"""
+    PERIOD = 0x37
+    """``.`` and ``>``"""
+    FORWARD_SLASH = 0x38
+    """``/`` and ``?``"""
+
+    CAPS_LOCK = 0x39
+    """Caps Lock"""
+
+    F1 = 0x3A
+    """Function key F1"""
+    F2 = 0x3B
+    """Function key F2"""
+    F3 = 0x3C
+    """Function key F3"""
+    F4 = 0x3D
+    """Function key F4"""
+    F5 = 0x3E
+    """Function key F5"""
+    F6 = 0x3F
+    """Function key F6"""
+    F7 = 0x40
+    """Function key F7"""
+    F8 = 0x41
+    """Function key F8"""
+    F9 = 0x42
+    """Function key F9"""
+    F10 = 0x43
+    """Function key F10"""
+    F11 = 0x44
+    """Function key F11"""
+    F12 = 0x45
+    """Function key F12"""
+
+    PRINT_SCREEN = 0x46
+    """Print Screen (SysRq)"""
+    SCROLL_LOCK = 0x47
+    """Scroll Lock"""
+    PAUSE = 0x48
+    """Pause (Break)"""
+
+    INSERT = 0x49
+    """Insert"""
+    HOME = 0x4A
+    """Home (often moves to beginning of line)"""
+    PAGE_UP = 0x4B
+    """Go back one page"""
+    DELETE = 0x4C
+    """Delete forward"""
+    END = 0x4D
+    """End (often moves to end of line)"""
+    PAGE_DOWN = 0x4E
+    """Go forward one page"""
+
+    RIGHT_ARROW = 0x4F
+    """Move the cursor right"""
+    LEFT_ARROW = 0x50
+    """Move the cursor left"""
+    DOWN_ARROW = 0x51
+    """Move the cursor down"""
+    UP_ARROW = 0x52
+    """Move the cursor up"""
+
+    KEYPAD_NUMLOCK = 0x53
+    """Num Lock (Clear on Mac)"""
+    KEYPAD_FORWARD_SLASH = 0x54
+    """Keypad ``/``"""
+    KEYPAD_ASTERISK = 0x55
+    """Keypad ``*``"""
+    KEYPAD_MINUS = 0x56
+    """Keyapd ``-``"""
+    KEYPAD_PLUS = 0x57
+    """Keypad ``+``"""
+    KEYPAD_ENTER = 0x58
+    """Keypad Enter"""
+    KEYPAD_ONE = 0x59
+    """Keypad ``1`` and End"""
+    KEYPAD_TWO = 0x5A
+    """Keypad ``2`` and Down Arrow"""
+    KEYPAD_THREE = 0x5B
+    """Keypad ``3`` and PgDn"""
+    KEYPAD_FOUR = 0x5C
+    """Keypad ``4`` and Left Arrow"""
+    KEYPAD_FIVE = 0x5D
+    """Keypad ``5``"""
+    KEYPAD_SIX = 0x5E
+    """Keypad ``6`` and Right Arrow"""
+    KEYPAD_SEVEN = 0x5F
+    """Keypad ``7`` and Home"""
+    KEYPAD_EIGHT = 0x60
+    """Keypad ``8`` and Up Arrow"""
+    KEYPAD_NINE = 0x61
+    """Keypad ``9`` and PgUp"""
+    KEYPAD_ZERO = 0x62
+    """Keypad ``0`` and Ins"""
+    KEYPAD_PERIOD = 0x63
+    """Keypad ``.`` and Del"""
+    KEYPAD_BACKSLASH = 0x64
+    """Keypad ``\\`` and ``|`` (Non-US)"""
+
+    APPLICATION = 0x65
+    """Application: also known as the Menu key (Windows)"""
+    POWER = 0x66
+    """Power (Mac)"""
+    KEYPAD_EQUALS = 0x67
+    """Keypad ``=`` (Mac)"""
+    F13 = 0x68
+    """Function key F13 (Mac)"""
+    F14 = 0x69
+    """Function key F14 (Mac)"""
+    F15 = 0x6A
+    """Function key F15 (Mac)"""
+    F16 = 0x6B
+    """Function key F16 (Mac)"""
+    F17 = 0x6C
+    """Function key F17 (Mac)"""
+    F18 = 0x6D
+    """Function key F18 (Mac)"""
+    F19 = 0x6E
+    """Function key F19 (Mac)"""
+
+    F20 = 0x6F
+    """Function key F20"""
+    F21 = 0x70
+    """Function key F21"""
+    F22 = 0x71
+    """Function key F22"""
+    F23 = 0x72
+    """Function key F23"""
+    F24 = 0x73
+    """Function key F24"""
+
+    LEFT_CONTROL = 0xE0
+    """Control modifier left of the spacebar"""
+    CONTROL = LEFT_CONTROL
+    """Alias for LEFT_CONTROL"""
+    LEFT_SHIFT = 0xE1
+    """Shift modifier left of the spacebar"""
+    SHIFT = LEFT_SHIFT
+    """Alias for LEFT_SHIFT"""
+    LEFT_ALT = 0xE2
+    """Alt modifier left of the spacebar"""
+    ALT = LEFT_ALT
+    """Alias for LEFT_ALT; Alt is also known as Option (Mac)"""
+    OPTION = ALT
+    """Labeled as Option on some Mac keyboards"""
+    LEFT_GUI = 0xE3
+    """GUI modifier left of the spacebar"""
+    GUI = LEFT_GUI
+    """Alias for LEFT_GUI; GUI is also known as the Windows key, Command (Mac), or Meta"""
+    WINDOWS = GUI
+    """Labeled with a Windows logo on Windows keyboards"""
+    COMMAND = GUI
+    """Labeled as Command on Mac keyboards, with a clover glyph"""
+    RIGHT_CONTROL = 0xE4
+    """Control modifier right of the spacebar"""
+    RIGHT_SHIFT = 0xE5
+    """Shift modifier right of the spacebar"""
+    RIGHT_ALT = 0xE6
+    """Alt modifier right of the spacebar"""
+    RIGHT_GUI = 0xE7
+    """GUI modifier right of the spacebar"""
+
+    # pylint: enable-msg=invalid-name
+    @classmethod
+    def modifier_bit(cls, keycode: int) -> int:
+        """Return the modifer bit to be set in an HID keycode report if this is a
+        modifier key; otherwise return 0."""
+        return 1 << (keycode - 0xE0) if cls.LEFT_CONTROL <= keycode <= cls.RIGHT_GUI else 0

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -818,11 +818,6 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         await self._atv.audio.volume_down()
 
     @async_handle_atvlib_errors
-    async def mute_toggle(self) -> ucapi.StatusCodes:
-        """Press key mute toggle."""
-        await self._send_hid_key(12, 0xE2)
-
-    @async_handle_atvlib_errors
     async def cursor_up(self) -> ucapi.StatusCodes:
         """Press key up."""
         await self._atv.remote_control.up()
@@ -964,7 +959,8 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         else:
             raise pyatv.exceptions.CommandError("Touch gestures not supported")
 
-    async def _send_hid_key(self, use_page: int, usage: int) -> None:
+    @async_handle_atvlib_errors
+    async def send_hid_key(self, use_page: int, usage: int) -> ucapi.StatusCodes:
         """Send a short HID key press.
 
         :param use_page: HID usage page (1 Generic Desktop, 7 Keyboard, 12 Consumer)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 120
+exclude = hid
 
 [isort]
 profile=black


### PR DESCRIPTION
Add new simple command `PLAY_PAUSE_KEY` which sends consumer page usage code 0xCD, which is the same as Bluetooth control uses. This seems to work better than the MRP play_pause command. E.g. pressing play/pause within Plex now automatically starts the selected movie.

This requires more testing with the reported apps having issue with the default MRP play_pause command. If it works, we can make it the default play/pause action in the media-player entity.

Relates to: unfoldedcircle/feature-and-bug-tracker#159