### PR TITLE
New global volume management 

### DIFF
--- a/intg-appletv/config.py
+++ b/intg-appletv/config.py
@@ -44,7 +44,8 @@ class AtvDevice:
     """Optional IP address of device. Disables IP discovery by identifier."""
     mac_address: str | None = None
     """Actual identifier of the device, which can change over time."""
-
+    global_volume: bool | None = True
+    """Change volume on all connected devices."""
 
 class _EnhancedJSONEncoder(json.JSONEncoder):
     """Python dataclass json encoder."""
@@ -116,6 +117,7 @@ class Devices:
                 item.address = atv.address
                 item.name = atv.name
                 item.address = atv.address
+                item.global_volume = atv.global_volume if atv.global_volume else True
                 return self.store()
         return False
 
@@ -175,6 +177,7 @@ class Devices:
                     item.get("credentials"),
                     item.get("address"),
                     item.get("mac_address"),
+                    item.get("global_volume", True)
                 )
                 self._config.append(atv)
             return True

--- a/intg-appletv/config.py
+++ b/intg-appletv/config.py
@@ -47,6 +47,7 @@ class AtvDevice:
     global_volume: bool | None = True
     """Change volume on all connected devices."""
 
+
 class _EnhancedJSONEncoder(json.JSONEncoder):
     """Python dataclass json encoder."""
 
@@ -177,7 +178,7 @@ class Devices:
                     item.get("credentials"),
                     item.get("address"),
                     item.get("mac_address"),
-                    item.get("global_volume", True)
+                    item.get("global_volume", True),
                 )
                 self._config.append(atv)
             return True

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -227,6 +227,8 @@ async def media_player_cmd_handler(
             res = await device.volume_up()
         case media_player.Commands.VOLUME_DOWN:
             res = await device.volume_down()
+        case media_player.Commands.VOLUME:
+            res = await device.volume_set(params.get("volume"))
         case media_player.Commands.MUTE_TOGGLE:
             res = await device.send_hid_key(UsagePage.CONSUMER, ConsumerControlCode.MUTE)
         case media_player.Commands.ON:

--- a/intg-appletv/setup_flow.py
+++ b/intg-appletv/setup_flow.py
@@ -352,6 +352,14 @@ async def _handle_configuration_mode(msg: UserDataResponse) -> RequestUserInput 
                             "fr": "Adresse IP (optionnelle)",
                         },
                     },
+                    {
+                        "id": "global_volume",
+                        "label": {
+                            "en": "Change volume on all connected devices",
+                            "fr": "Régler le volume sur tous les appareils connectés",
+                        },
+                        "field": {"checkbox": {"value": True}},
+                    },
                 ],
             )
 
@@ -432,7 +440,15 @@ async def _handle_discovery(msg: UserDataResponse) -> RequestUserInput | SetupEr
                     "de": "Wähle deinen Apple TV",
                     "fr": "Choisissez votre Apple TV",
                 },
-            }
+            },
+            {
+                "id": "global_volume",
+                "label": {
+                    "en": "Change volume on all connected devices",
+                    "fr": "Régler le volume sur tous les appareils connectés",
+                },
+                "field": {"checkbox": {"value": True}},
+            },
         ],
     )
 
@@ -450,6 +466,7 @@ async def _handle_device_choice(msg: UserDataResponse) -> RequestUserInput | Set
     global _setup_step
 
     choice = msg.input_values["choice"]
+    global_volume = msg.input_values.get("global_volume", "true") == "true"
 
     atv = _discovered_atv_from_identifier(choice)
     if atv is None:
@@ -473,6 +490,7 @@ async def _handle_device_choice(msg: UserDataResponse) -> RequestUserInput | Set
             credentials=[],
             address=atv.address if _manual_address else None,
             mac_address=choice,
+            global_volume=global_volume
         ),
         loop=asyncio.get_event_loop(),
         pairing_atv=atv,
@@ -600,6 +618,7 @@ async def _handle_user_data_companion_pin(msg: UserDataResponse) -> SetupComplet
         credentials=_pairing_apple_tv.get_credentials(),
         address=_pairing_apple_tv.address,
         mac_address=_pairing_apple_tv.identifier,
+        global_volume=_pairing_apple_tv.device_config.global_volume
     )
     config.devices.add_or_update(device)  # triggers ATV instance creation
 
@@ -629,6 +648,7 @@ async def _handle_device_reconfigure(msg: UserDataResponse) -> SetupComplete | S
 
     mac_address = msg.input_values["mac_address"]
     manual_mac_address = msg.input_values["manual_mac_address"]
+    global_volume = msg.input_values.get("global_volume", "true") == "true"
 
     if mac_address == "" and manual_mac_address == "":
         _LOG.error("Mac address is mandatory, no changes applied")
@@ -642,6 +662,7 @@ async def _handle_device_reconfigure(msg: UserDataResponse) -> SetupComplete | S
     _LOG.debug("User has changed configuration")
     _reconfigured_device.mac_address = mac_address
     _reconfigured_device.address = address
+    _reconfigured_device.global_volume = global_volume
 
     config.devices.add_or_update(_reconfigured_device)  # triggers ATV instance update
 

--- a/intg-appletv/setup_flow.py
+++ b/intg-appletv/setup_flow.py
@@ -490,7 +490,7 @@ async def _handle_device_choice(msg: UserDataResponse) -> RequestUserInput | Set
             credentials=[],
             address=atv.address if _manual_address else None,
             mac_address=choice,
-            global_volume=global_volume
+            global_volume=global_volume,
         ),
         loop=asyncio.get_event_loop(),
         pairing_atv=atv,
@@ -618,7 +618,7 @@ async def _handle_user_data_companion_pin(msg: UserDataResponse) -> SetupComplet
         credentials=_pairing_apple_tv.get_credentials(),
         address=_pairing_apple_tv.address,
         mac_address=_pairing_apple_tv.identifier,
-        global_volume=_pairing_apple_tv.device_config.global_volume
+        global_volume=_pairing_apple_tv.device_config.global_volume,
     )
     config.devices.add_or_update(device)  # triggers ATV instance creation
 

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -65,6 +65,7 @@ ARTWORK_HEIGHT = 400
 
 # pylint: disable=too-many-lines
 
+
 class EVENTS(IntEnum):
     """Internal driver events."""
 


### PR DESCRIPTION
New global volume management 
Currently when you enable additional output devices to stream audio to, the volume cannot be set on these devices. 
Besides the main volume may not be modified at all if the AppleTV is connected to a HT receiver and will remain to 0.

With this modification, we can now set volume by level and also apply this volume level to all connected devices.
Also the reported volume reflects the average sum of all volume levels like in the notification center of the iOS device (see capture below).

Modifications applied :
1. Added support to set volume with a given level (features updated)
2. The volume is applied to all connected devices unless the user uncheck it in the setup flow/reconfigure flow. By default this new setting is enabled and can be disabled by user
3. The reported volume level is now updated with an average value of all volume levels (if option enabled), otherwise main volume only like today

I was able to test it successfully on my setup:

1. Select at least one additional device to stream audio to : AppleTV + homepod for ex
2. Set the volume level to any value (eg 50)
3. The volume is updated to all connected devices including the homepod

See the following capture :
<img src="https://github.com/user-attachments/assets/6ba785c3-f279-4dfc-8293-0d5764692bb1" width="200px">

This PR will have to be updated later once the other PR on pyatv will be merged : https://github.com/postlund/pyatv/pull/2673
