### PR TITLE
feat: set media player attribute `media_position_updated_at`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Added
+- Set media player attribute "media_position_updated_at" ([feature-and-bug-tracker#443](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/443)).
+
 ---
 
 ## v0.17.0 - 2025-04-06

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 import os
 import sys
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
@@ -438,6 +439,7 @@ async def on_atv_update(entity_id: str, update: dict[str, Any] | None) -> None:
         and target_entity.attributes.get(media_player.Attributes.MEDIA_POSITION, 0) != update["position"]
     ):
         attributes[media_player.Attributes.MEDIA_POSITION] = update["position"]
+        attributes["media_position_updated_at"] = datetime.now(tz=UTC).isoformat()
     if (
         "total_time" in update
         and target_entity.attributes.get(media_player.Attributes.MEDIA_DURATION, 0) != update["total_time"]


### PR DESCRIPTION
Set the media position update timestamp in `media_position_updated_at`.
Relates to https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/443