### PR TITLE
Externalize language texts with gettext, Crowdin integration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Create a report to help us improve
+title: '<title>'
+labels: [bug]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check the existing issues first to see if the bug has already been recorded.
+        If you have more information about an existing bug, please add it as a comment and don't open a new issue.
+        Thank you!
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: How to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. ...
+        2. ...
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: input
+    id: intg_version
+    attributes:
+      label: Integration version
+      description: You can find the integration version in driver.json or in the UI under Settings/Integrations
+      placeholder: ex. v0.4.5
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context about the problem here. Otherwise you can ignore this section.
+        How has this issue affected you? What are you trying to accomplish?
+        Providing context helps us come up with a solution that is most useful in the real world
+        
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Unfolded Circle Community Forum
+    url: https://unfolded.community/
+    about: Please ask and answer questions here.
+  - name: Unfolded Circle Discord Channel
+    url: https://unfolded.chat/
+    about: Chat with the community and for asking questions.
+  - name: Unfolded Circle Contact Form
+    url: https://unfoldedcircle.com/contact
+    about: Write us a message on our website.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest an idea
+title: '<title>'
+labels: [enhancement]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check the existing issues first to see if your feature request has already been recorded.
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and concise description of what the feature request is about.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context or screenshots about the feature request here.
+        
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
   pull_request:
+    branches:
+      - main
     types: [ opened, synchronize, reopened ]
 
 env:
@@ -43,9 +45,15 @@ jobs:
             exit 1
           fi
 
-      - name: Build
+      - name: Compile language files
         run: |
-          sudo apt-get update && sudo apt-get install -y qemu-system-arm binfmt-support qemu-user-static
+          sudo apt-get update && sudo apt-get install -y gettext
+          cd intg-appletv/locales
+          make all
+
+      - name: Pyinstaller
+        run: |
+          sudo apt-get install -y qemu-system-arm binfmt-support qemu-user-static
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           echo "Starting pyinstaller build"
           docker run --rm --name builder \
@@ -56,7 +64,10 @@ jobs:
             bash -c \
             "cd /workspace && \
               python -m pip install -r requirements.txt && \
-              pyinstaller --clean --onedir --name intg-appletv --collect-all zeroconf intg-appletv/driver.py"
+              pyinstaller --clean --onedir --name intg-appletv --add-data intg-appletv/locales:locales --collect-all zeroconf intg-appletv/driver.py"
+          echo "Clean up locales"
+          cd dist/intg-appletv/_internal/locales
+          rm -Rf *.pot Makefile README.md */LC_MESSAGES/*.po
 
       - name: Add version
         run: |

--- a/.github/workflows/python-code-format.yml
+++ b/.github/workflows/python-code-format.yml
@@ -2,6 +2,8 @@ name: Check Python code formatting
 
 on:
   push:
+    branches-ignore:
+      - l10n
     paths:
       - 'intg-appletv/**'
       - 'requirements.txt'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Changed
+- Externalize language strings for translations with Crowdin ([#12](https://github.com/unfoldedcircle/integration-appletv/issues/12)))
+
 ---
 
 ## v0.18.1 - 2025-04-26

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This integration is based on the great [pyatv](https://github.com/postlund/pyatv) library and uses our
 [uc-integration-api](https://github.com/aitatoi/integration-python-library) to communicate with the Remote Two/3.
+[Crowdin translations](https://crowdin.com/project/uc-integration-appletv).
 
 The driver discovers Apple TV devices on the network and pairs them using AirPlay and companion protocols.
 A [media player entity](https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/entity_media_player.md)
@@ -39,7 +40,7 @@ Supported commands:
 
 Please note:
 - Certain commands like channel up & down are app dependant and don't work with every app!
-- Media information and artwork are not provided by every app.
+- Not every app provides media information and artwork.
 
 ## Requirements
 
@@ -77,6 +78,18 @@ issue in the library with all the required information to reproduce it.
   (using a [virtual environment](https://docs.python.org/3/library/venv.html) is highly recommended)
 ```shell
 pip3 install -r requirements.txt
+```
+
+- The integration is runnable without updating the language files or compiling the .po files!  
+  If a language file is missing, the language key is used which in most cases is identical to the English language text.
+- Optional: compile gettext translation files:
+  - This requires `msgfmt` from the GNU gettext utilities.
+  - See [docs/i18n.md](docs/i18n.md) for more information.
+  - Helper Makefile:
+  
+```shell
+cd intg-appletv/locales
+make all
 ```
 
 For running a separate integration driver on your network for Remote Two/3, the configuration in file
@@ -132,7 +145,8 @@ docker run --rm --name builder \
     docker.io/unfoldedcircle/r2-pyinstaller:3.11.12  \
     bash -c \
       "python -m pip install -r requirements.txt && \
-      pyinstaller --clean --onedir --name intg-appletv --collect-all zeroconf intg-appletv/driver.py"
+      pyinstaller --clean --onedir --name intg-appletv \
+        --add-data intg-appletv/locales:locales --collect-all zeroconf intg-appletv/driver.py"
 ```
 
 ### aarch64 Linux / Mac
@@ -145,7 +159,8 @@ docker run --rm --name builder \
     docker.io/unfoldedcircle/r2-pyinstaller:3.11.12  \
     bash -c \
       "python -m pip install -r requirements.txt && \
-      pyinstaller --clean --onedir --name intg-appletv --collect-all zeroconf intg-appletv/driver.py"
+      pyinstaller --clean --onedir --name intg-appletv \
+        --add-data intg-appletv/locales:locales --collect-all zeroconf intg-appletv/driver.py"
 ```
 
 ## Versioning

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This integration is based on the great [pyatv](https://github.com/postlund/pyatv) library and uses our
 [uc-integration-api](https://github.com/aitatoi/integration-python-library) to communicate with the Remote Two/3.
-[Crowdin translations](https://crowdin.com/project/uc-integration-appletv).
+[Crowdin translations](https://crowdin.com/project/uc-integration-apple-tv).
 
 The driver discovers Apple TV devices on the network and pairs them using AirPlay and companion protocols.
 A [media player entity](https://github.com/unfoldedcircle/core-api/blob/main/doc/entities/entity_media_player.md)

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,5 @@
+commit_message: "fix: New %language% translations from Crowdin [ci skip]"
+append_commit_message: false
+files:
+  - source: /intg-appletv/locales/en_US/**/*.po
+    translation: /intg-appletv/locales/%locale_with_underscore%/**/%original_file_name%

--- a/docs/code_guidelines.md
+++ b/docs/code_guidelines.md
@@ -1,4 +1,4 @@
-# Code Style
+# Code Guidelines
 
 - Code line length: 120
 - Use double quotes as default (don't mix and match for simple quoting, checked with pylint).
@@ -46,3 +46,51 @@ PyCharm/IntelliJ IDEA integration:
 ```shell
 python -m isort intg-appletv/.
 ```
+
+## Language Texts
+
+Only end-user texts must be prepared for translation with the Python [gettext](https://docs.python.org/3.11/library/gettext.html)
+module. Helper functions are defined in [i18n.py](../intg-appletv/i18n.py).
+
+- Do not translate log messages.
+- See the setup-flow code on how to use language texts.
+- For more information, see [i18n.md](i18n.md).
+
+For a pull request, a properly updated English reference language file [intg-appletv/locales/en_US/LC_MESSAGES/intg-appletv.po](../intg-appletv/locales/en_US/LC_MESSAGES/intg-appletv.po)
+is appreciated, but not mandatory. We understand that it can be a challenge if gettext hasn't been used before and the
+development machine is Windows :-)
+
+Minimally required are wrapped language texts in the Python code. A pull request reviewer can easily update the language
+files after merging the PR if the translations are properly prepared in the Python code.
+
+## Third-Party Libraries
+
+The use of third-party libraries is encouraged when specific functionality is not provided by Python's standard library.
+However, since this integration is included in the Remote firmware, the following requirements must be met:
+
+### License Requirements
+
+- Verify that the library's license is compatible with the project's [Mozilla Public License 2.0](https://choosealicense.com/licenses/mpl-2.0/).
+- Prohibited licenses:
+  - GPLv3 and its variants.
+- The library's license information must be retrievable with the `pip-licenses` tool.
+
+### Maintenance and Security
+
+- Libraries must be actively maintained with:
+  - Regular updates and bug fixes.
+  - Updated dependencies.
+  - Remain compatible with the Python version used in the integration.
+- Specify version requirements:
+  - Use semantic versioning in requirements.txt
+  - Pin library version for stability.
+
+### Approval Process
+
+- The Unfolded Circle core team must approve any external library.  
+  Please reach out before opening a pull request with a GitHub issue or a direct message.
+- Approval documentation required in:
+  - GitHub issue or pull request.
+  - Include justification for the library.
+  - List alternatives considered.
+- Non-approved libraries will result in declined pull requests.

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -2,7 +2,7 @@
 
 This project uses the Python [gettext](https://docs.python.org/3.11/library/gettext.html) module for internationalization.
 
-- Crowdin is used to translate texts: https://crowdin.com/project/uc-integration-appletv
+- Crowdin is used to translate texts: https://crowdin.com/project/uc-integration-apple-tv
 - English is used as the reference language for all translations.
   - The English text is used as the language-key, as it is commonly used in GNU gettext.
   - Exceptions are for very long texts, where a summary text is enough, or omitting web-links or other formatting options.
@@ -105,7 +105,7 @@ language .po file should be avoided.
 ```shell
 xgettext -d intg-appletv -o intg-appletv/locales/intg-appletv.pot --from-code=UTF-8 --language=Python \
     --add-comments=Translators --keyword=_ --keyword=_n:1,2 --keyword=__ --keyword=_a --no-wrap \
-    --copyright-holder="Unfolded Circle ApS" --package-name "uc-integration-appletv" \
+    --copyright-holder="Unfolded Circle ApS" --package-name "uc-integration-apple-tv" \
     intg-appletv/*.py
 ```
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,164 @@
+# Internationalization (i18n) for Apple TV Integration
+
+This project uses the Python [gettext](https://docs.python.org/3.11/library/gettext.html) module for internationalization.
+
+- Crowdin is used to translate texts: https://crowdin.com/project/uc-integration-appletv
+- English is used as the reference language for all translations.
+  - The English text is used as the language-key, as it is commonly used in GNU gettext.
+  - Exceptions are for very long texts, where a summary text is enough, or omitting web-links or other formatting options.
+- Only the English .po file may be edited and committed to Git!
+  - All other languages are translated by Crowdin.
+  - Updated texts are pushed back as pull requests. 
+- ‼️ Language texts used in the Integration-API messages are currently not single language texts but dictionaries with
+     all languages.
+
+Don't fear gettext :-)
+It might seem complicated if you haven't used it before, but the integration is runnable even without updating the
+language files or compiling the .po files! If a language file is missing, the language key is used which in most cases
+is identical to the English language text.
+
+## Directory Structure
+
+The locales directory is organized as follows:
+
+```
+intg-appletv
+└── locales/
+    ├── en_US/
+    │   └── LC_MESSAGES/
+    │       └── intg-appletv.po
+    ├── de_DE/
+    │   └── LC_MESSAGES/
+    │       └── intg-appletv.po
+    ├── fr_FR/
+    │   └── LC_MESSAGES/
+    │       └── intg-appletv.po
+    └── intg-appletv.pot
+```
+
+- `intg-appletv.pot`: The template file containing all translatable strings extracted from the source files.
+  - This file is temporary and not committed to Git. 
+- `<language>/LC_MESSAGES/intg-appletv.po`: Translation files for each supported language.
+- Country suffixes are used to prepare country-specific translations, for example `en_UK`, `de_CH`, etc.
+
+## Working with Translations
+
+‼️ The translated texts in the setup-flow are not single texts in a specific language, but dictionaries with all
+   available languages! 
+
+Most language texts must be included as key value pairs. Example:
+
+```json
+{
+  "label": {
+    "en": "Good morning",
+    "fr": "Bonjour",
+    "de": "Guten Morgen"
+  }
+}
+```
+
+See the [Integration-API](https://github.com/unfoldedcircle/core-api/tree/main/integration-api) for more information.
+
+To support these multi-language translations without too much boilerplate code, new shorthand functions are defined
+in [i18n.py](../intg-appletv/i18n.py) which complement the common `_` translation function:
+
+- `_a`: create a translation dictionary for all available languages (instead a single translation with `_`).
+- `_am`: same as `_a` but for longer texts concatenated by multiple message ids.
+- `__`: passthrough function without translation, only for text extraction with `xgettext` and `_am` helper.
+
+See "Usage in Code" below on how to use these functions.
+
+This might change in the future and can be easily adapted when necessary with the defined shorthand functions:
+replace the custom `_a` and `_am` functions with the common `_` translation function.
+
+### Usage in Python
+
+Use the i18n module as follows:
+
+```python
+from i18n import _, _n, _a, _am, __
+
+# Simple translation
+print(_("Hello, world!"))
+
+# Pluralization
+count = 5
+print(_n("Found %d item", "Found %d items", count) % count)
+
+# For setup-flow messages that expect a dictionary with language codes
+setup_text = _a("Setup mode")
+
+# For longer setup-flow messages consisting of multiple messages
+long_setup_text = _am(
+   __("Leave blank to use auto-discovery and click _Next_."),
+   "\n\n",
+   __("The device must be on the same network as the remote."),
+)
+```
+
+### Extracting Strings
+
+To extract translatable strings from the source code, the `xgettext` tool should be used. Manual editing the reference
+language .po file should be avoided.
+
+```shell
+xgettext -d intg-appletv -o intg-appletv/locales/intg-appletv.pot --from-code=UTF-8 --language=Python \
+    --add-comments=Translators --keyword=_ --keyword=_n:1,2 --keyword=__ --keyword=_a --no-wrap \
+    --copyright-holder="Unfolded Circle ApS" --package-name "uc-integration-appletv" \
+    intg-appletv/*.py
+```
+
+- This creates the `intg-appletv/locales/intg-appletv.pot` template file.
+- Source code file & linenumber metadata is automatically updated. 
+- `--no-wrap` is used for better Crowdin merge compatibility.
+
+To update and compile all .po files, the helper Makefile in `intg-appletv/locales` can be used:
+
+```shell
+cd intg-appletv/locales
+make update_po
+make all
+```
+
+### Updating Translation Files
+
+‼️ Only the English reference language `en_US` should be updated. All other language files are handled by Crowdin!
+
+```shell
+LANGUAGE=en_US
+msgmerge --no-wrap -U intg-appletv/locales/$LANGUAGE/LC_MESSAGES/intg-appletv.po \
+    intg-appletv/locales/intg-appletv.pot
+```
+
+### Compiling Translation Files
+
+To compile the .po files into binary .mo files that can be used by the application:
+
+```shell
+LANGUAGE=en_US
+msgfmt intg-appletv/locales/$LANGUAGE/LC_MESSAGES/intg-appletv.po \
+    -o intg-appletv/locales/$LANGUAGE/LC_MESSAGES/intg-appletv.mo
+```
+
+### Create New Translation Files
+
+‼️ This is for reference and local use only. New project translation languages must be requested and created in Crowdin.
+
+To create a new language, for example `en_UK`:
+
+```shell
+LANGUAGE=en_UK
+mkdir -p "intg-appletv/locales/$LANGUAGE/LC_MESSAGES"
+msginit --no-wrap -i intg-appletv/locales/intg-appletv.pot \
+    -o intg-appletv/locales/$LANGUAGE/LC_MESSAGES/intg-appletv.po \
+    -l $LANGUAGE
+```
+
+# Resources
+
+- https://docs.python.org/3.11/library/gettext.html
+- https://crowdin.com/blog/2022/09/28/python-app-translation-tutorial
+- https://phrase.com/blog/posts/translate-python-gnu-gettext/
+- https://phrase.com/blog/posts/learn-gettext-tools-internationalization/
+- https://lokalise.com/blog/beginners-guide-to-python-i18n/

--- a/driver.json
+++ b/driver.json
@@ -1,13 +1,11 @@
 {
 	"driver_id": "appletv",
 	"version": "0.18.1",
-	"min_core_api": "0.7.0",
+	"min_core_api": "0.7.1",
 	"name": { "en": "Apple TV" },
 	"icon": "uc:integration",
 	"description": {
-		"en": "Control your Apple TV with Remote Two/3.",
-		"de": "Steuere Apple TV mit Remote Two/3.",
-		"fr": "Contrôler votre Apple TV avec Remote Two/3."
+		"_comment": "set at runtime"
 	},
 	"developer": {
 		"name": "Unfolded Circle ApS",
@@ -16,30 +14,7 @@
 	},
 	"home_page": "https://www.unfoldedcircle.com",
 	"setup_data_schema": {
-		"title": {
-			"en": "Integration setup",
-			"de": "Integrationssetup",
-			"fr": "Configuration de l'intégration"
-		},
-		"settings": [
-			{
-				"id": "info",
-				"label": {
-					"en": "Setup process",
-					"de": "Setup Fortschritt",
-					"fr": "Progression de la configuration"
-				},
-				"field": {
-					"label": {
-						"value": {
-							"en": "The integration will discover your Apple TV on your network. Apple TV 4 and newer are supported and the device must be on the same network as the remote. During the process, you need to enter multiple PINs that are shown on your Apple TV. Please make sure to set AirPlay access to _Anyone on the Same Network_ in Apple TV settings.\n\nPlease see our [support article](https://support.unfoldedcircle.com/hc/en-us/articles/19479576638620) for requirements, features and restrictions.",
-							"de": "Die Integration wird dein Apple TV in deinem Netzwerk erkennen. Apple TV 4 und neuer werden unterstützt und das Gerät muss sich im gleichen Netzwerk wie die Fernbedienung befinden. Während des Prozesses must du mehrere PINs eingeben, die auf deinem Apple TV angezeigt werden. Bitte stelle sicher, dass der AirPlay-Zugriff in den Apple TV-Einstellungen auf _Für jeden im selben Netzwerk_ eingestellt ist.\n\nBitte beachte unseren [Support-Artikel](https://support.unfoldedcircle.com/hc/en-us/articles/19479576638620) zu Anforderungen, unterstützten Funktionen und Einschränkungen.",
-							"fr": "L'intégration découvrira votre Apple TV sur votre réseau. Apple TV 4 et plus récentes sont prises en charge et l'appareil doit être sur le même réseau que la télécommande. Au cours du processus, vous devez saisir plusieurs codes PIN qui s'affichent sur votre Apple TV. Veillez à ce que l'accès AirPlay soit réglé sur _Toute personne sur le même réseau_ dans les réglages de l'Apple TV.\n\nVeuillez consulter [l’article de support](https://support.unfoldedcircle.com/hc/en-us/articles/19479576638620) pour connaître les exigences, les fonctionnalités prises en charge et les restrictions."
-						}
-					}
-				}
-			}
-		]
+		"_comment": "set at runtime"
 	},
 	"release_date": "2025-04-26"
 }

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -29,6 +29,7 @@ import ucapi
 import ucapi.api as uc
 from hid import UsagePage
 from hid.consumer_control_code import ConsumerControlCode
+from i18n import _a
 from ucapi import MediaPlayer, media_player
 
 _LOG = logging.getLogger("driver")  # avoid having __main__ in log messages
@@ -712,6 +713,9 @@ async def main():
         _register_available_entities(device.identifier, device.name)
 
     await api.init("driver.json", setup_flow.driver_setup_handler)
+    # temporary hack to change driver.json language texts until supported by the wrapper lib
+    api._driver_info["description"] = _a("Control your Apple TV with Remote Two/3.")  # pylint: disable=W0212
+    api._driver_info["setup_data_schema"] = setup_flow.setup_data_schema()  # pylint: disable=W0212
 
 
 if __name__ == "__main__":

--- a/intg-appletv/i18n.py
+++ b/intg-appletv/i18n.py
@@ -1,0 +1,223 @@
+"""
+Internationalization support for the Apple TV integration.
+
+This module provides functions for translating strings in the integration.
+It uses gettext for internationalization and proper pluralization support.
+This implementation is compatible with Crowdin for translation management.
+
+:copyright: (c) 2025 by Unfolded Circle ApS.
+:license: Mozilla Public License Version 2.0, see LICENSE for more details.
+"""
+
+import os
+from gettext import NullTranslations, translation
+from pathlib import Path
+from typing import Dict, Optional
+
+# Define the available languages
+AVAILABLE_LANGUAGES = ["en_US", "de_DE", "fr_FR"]
+DEFAULT_LANGUAGE = "en_US"
+
+# Path to the locales directory (relative to the package)
+LOCALE_DIR = Path(__file__).parent / "locales"
+
+# Cache for translators to avoid creating them multiple times
+_translators: Dict[str, NullTranslations] = {}
+
+# Current language # pylint: disable=C0103
+_current_language = DEFAULT_LANGUAGE
+
+
+def setup_i18n(locale_dir: Optional[str] = None) -> None:
+    """
+    Set up the internationalization system.
+
+    This function should be called at the start of the application to ensure
+    the locales directory exists and is properly set up.
+
+    :param locale_dir: Optional path to the ``locales`` directory. If not provided,
+                      the default locales directory will be used.
+    """
+    global LOCALE_DIR
+
+    if locale_dir:
+        LOCALE_DIR = Path(locale_dir)
+
+    # Ensure the locales directory exists
+    os.makedirs(LOCALE_DIR, exist_ok=True)
+
+    # Create language directories if they don't exist
+    for lang in AVAILABLE_LANGUAGES:
+        lang_dir = LOCALE_DIR / lang / "LC_MESSAGES"
+        os.makedirs(lang_dir, exist_ok=True)
+
+
+def set_language(language: str) -> None:
+    """
+    Set the current language for translations.
+
+    :param language: The language code to use (e.g., 'en', 'de', 'fr')
+    """
+    global _current_language
+
+    if language in AVAILABLE_LANGUAGES:
+        _current_language = language
+    else:
+        _current_language = DEFAULT_LANGUAGE
+
+
+def get_translator(language: Optional[str] = None) -> NullTranslations:
+    """
+    Get a translator for the specified language.
+
+    :param language: The language code to use. If not provided, the current language will be used.
+    :return: A translator object for the specified language
+    """
+    lang = language or _current_language
+
+    if lang not in _translators:
+        try:
+            _translators[lang] = translation("intg-appletv", localedir=str(LOCALE_DIR), languages=[lang], fallback=True)
+        except (FileNotFoundError, OSError):
+            # Fallback to NullTranslations if the translation file doesn't exist
+            _translators[lang] = NullTranslations()
+
+    return _translators[lang]
+
+
+def gettext(message: str) -> str:
+    """
+    Translate a message using the current language.
+
+    :param message: The message to translate
+    :return: The translated message
+    """
+    translator = get_translator()
+    return translator.gettext(message)
+
+
+def ngettext(singular: str, plural: str, n: int) -> str:
+    """
+    Translate a singular/plural message using the current language.
+
+    This function handles proper pluralization based on the count and language rules.
+
+    :param singular: The singular form of the message
+    :param plural: The plural form of the message
+    :param n: The count that determines whether to use singular or plural
+    :return: The translated message with proper pluralization
+    """
+    translator = get_translator()
+    return translator.ngettext(singular, plural, n)
+
+
+def i18all(message: str) -> Dict[str, str]:
+    """
+    Create a translation dictionary for all available languages.
+
+    This is a helper function to create dictionaries in the format expected by the Core-API for setup-flow messages.
+    All language texts must be included as key value pairs, and not just a translation of the message. Example:
+
+    .. code-block:: json
+
+        {
+          "label": {
+            "en": "Good morning",
+            "fr": "Bonjour",
+            "de": "Guten Morgen"
+          }
+        }
+
+    This might change in the future and can be easily adapted when necessary with the defined shorthand functions:
+    just replace the custom ``_a`` and ``_am`` functions with the common ``_`` translation function.
+
+    :param message: message to translate
+    :return: A dictionary with language codes as keys and translated messages as values
+    """
+    result = {}
+    for lang in AVAILABLE_LANGUAGES:
+        translator = get_translator(lang)
+        result[lang] = translator.gettext(message)
+    return result
+
+
+def i18all_format(message: str, **kwargs) -> Dict[str, str]:
+    """
+    Create a translation dictionary for all available languages with a formatting operation.
+
+    The formatting operation is applied on every language text with the ``str.format()`` function.
+    This is a helper function to create dictionaries in the format expected by the Core-API for setup-flow messages.
+    All language texts must be included as key value pairs, and not just a translation of the message. Example:
+
+    .. code-block:: json
+
+        {
+          "label": {
+            "en": "Good morning $NAME",
+            "fr": "Bonjour $NAME",
+            "de": "Guten Morgen $NAME"
+          }
+        }
+
+    The above JSON structure can be built in Python the following way:
+
+    .. code-block:: python
+
+        msg = {
+          "label": i18all_format("Good morning {name}", name="Jane")
+        }
+
+    :param kwargs: map arguments to the formatting operation
+    :param message: message to translate
+    :return: A dictionary with language codes as keys and translated messages as values
+    """
+    result = {}
+    for lang in AVAILABLE_LANGUAGES:
+        translator = get_translator(lang)
+        result[lang] = translator.gettext(message).format_map(kwargs)
+    return result
+
+
+def i18all_multi(*args: str) -> Dict[str, str]:
+    """
+    Create a translation dictionary for all available languages with multiple messages.
+
+    All messages will be concatenated into a single string. This can be used for splitting up longer paragraphs or text
+    blocks for translation.
+
+    This is a helper function to create dictionaries in the format expected by the Core-API for setup-flow messages.
+
+    :param args: One or more messages to translate
+    :return: A dictionary with language codes as keys and translated messages as values
+    """
+    result = {}
+    for lang in AVAILABLE_LANGUAGES:
+        translator = get_translator(lang)
+        translated_messages = [translator.gettext(message) for message in args]
+        result[lang] = "".join(translated_messages)
+
+    return result
+
+
+def echo(message: str) -> str:
+    """
+    Marker function for gettext text extraction, the message is returned unchanged.
+
+    This is only used to extract the translation strings for the i18n module and in combination with the ``_am``
+    function.
+    :param message: message in the default language for xgettext extraction, returned unchanged.
+    :return:
+    """
+    return message
+
+
+# Define shorthand functions for easier use
+_ = gettext
+__ = echo
+_n = ngettext
+_a = i18all
+_af = i18all_format
+_am = i18all_multi
+
+# Initialize the i18n system
+setup_i18n()

--- a/intg-appletv/locales/Makefile
+++ b/intg-appletv/locales/Makefile
@@ -1,0 +1,17 @@
+LOCALES = de_DE fr_FR en_US
+PO_FILES = $(foreach loc,$(LOCALES),$(loc)/LC_MESSAGES/intg-appletv.po)
+MO_FILES = $(PO_FILES:.po=.mo)
+
+all: $(MO_FILES)
+
+%.mo: %.po
+	msgfmt -o $@ $<
+
+update_po:
+	xgettext -d intg-appletv -o intg-appletv.pot --from-code=UTF-8 --language=Python --add-comments=Translators --keyword=_ --keyword=_n:1,2 --keyword=__ --keyword=_a --no-wrap --copyright-holder="Unfolded Circle ApS" --package-name "uc-integration-appletv" ../*.py
+	$(foreach po,$(PO_FILES),msgmerge --no-wrap --update $(po) intg-appletv.pot;)
+
+clean:
+	rm -f */*/*.mo
+
+.PHONY: all update_po clean

--- a/intg-appletv/locales/Makefile
+++ b/intg-appletv/locales/Makefile
@@ -8,7 +8,7 @@ all: $(MO_FILES)
 	msgfmt -o $@ $<
 
 update_po:
-	xgettext -d intg-appletv -o intg-appletv.pot --from-code=UTF-8 --language=Python --add-comments=Translators --keyword=_ --keyword=_n:1,2 --keyword=__ --keyword=_a --no-wrap --copyright-holder="Unfolded Circle ApS" --package-name "uc-integration-appletv" ../*.py
+	xgettext -d intg-appletv -o intg-appletv.pot --from-code=UTF-8 --language=Python --add-comments=Translators --keyword=_ --keyword=_n:1,2 --keyword=__ --keyword=_a --no-wrap --copyright-holder="Unfolded Circle ApS" --package-name "uc-integration-apple-tv" ../*.py
 	$(foreach po,$(PO_FILES),msgmerge --no-wrap --update $(po) intg-appletv.pot;)
 
 clean:

--- a/intg-appletv/locales/README.md
+++ b/intg-appletv/locales/README.md
@@ -1,0 +1,6 @@
+# Internationalization (i18n)
+
+This directory contains translation files for the Apple TV integration. The integration uses the Python [gettext](https://docs.python.org/3.11/library/gettext.html)
+module for internationalization.
+
+See [/docs/i18n.md](../../docs/i18n.md) for more information.

--- a/intg-appletv/locales/README.md
+++ b/intg-appletv/locales/README.md
@@ -3,4 +3,19 @@
 This directory contains translation files for the Apple TV integration. The integration uses the Python [gettext](https://docs.python.org/3.11/library/gettext.html)
 module for internationalization.
 
+‼️Only the English .po file may be edited and committed to Git!
+- All other languages are translated by Crowdin.
+- Updated texts are pushed back as pull requests.
+
+Translations included in the build:
+- en_US (default)
+- de_DE
+- fr_FR
+
+See [Crowdin](https://crowdin.com/project/uc-integration-apple-tv) for current translation progress.
+
+How to enable additional translations:
+1. Edit [Makefile](Makefile) and add new language(s) to: `LOCALES = de_DE fr_FR en_US`
+2. Edit [i18n.py](../i18n.py) and add new language(s): `AVAILABLE_LANGUAGES = ["en_US", "de_DE", "fr_FR"]`
+
 See [/docs/i18n.md](../../docs/i18n.md) for more information.

--- a/intg-appletv/locales/de_DE/LC_MESSAGES/intg-appletv.po
+++ b/intg-appletv/locales/de_DE/LC_MESSAGES/intg-appletv.po
@@ -1,0 +1,139 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: uc-integration-appletv\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-04 14:51+0200\n"
+"PO-Revision-Date: 2025-06-03 16:09\n"
+"Last-Translator: Unfolded Circle <hello@unfoldedcircle.com>\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-SourceKey: msgstr\n"
+
+#: ../driver.py:717
+#, fuzzy
+msgid "Control your Apple TV with Remote Two/3."
+msgstr "Steuere Apple TV mit Remote Two/3."
+
+#: ../setup_flow.py:64
+msgid "Integration setup"
+msgstr "Integrationssetup"
+
+#: ../setup_flow.py:68
+msgid "Setup proces"
+msgstr "Setup Fortschritt"
+
+#: ../setup_flow.py:72
+msgid "The integration will discover your Apple TV on your network."
+msgstr "Die Integration wird dein Apple TV in deinem Netzwerk erkennen."
+
+#: ../setup_flow.py:75
+msgid "Apple TV 4 and newer are supported and the device must be on the same network as the remote."
+msgstr "Apple TV 4 und neuer werden unterstützt und das Gerät muss sich im gleichen Netzwerk wie die Fernbedienung befinden."
+
+#: ../setup_flow.py:79
+msgid "During the process, you need to enter multiple PINs that are shown on your Apple TV. Please make sure to set AirPlay access to _Anyone on the Same Network_ in Apple TV settings."
+msgstr "Während des Prozesses must du mehrere PINs eingeben, die auf deinem Apple TV angezeigt werden. Bitte stelle sicher, dass der AirPlay-Zugriff in den Apple TV-Einstellungen auf _Für jeden im selben Netzwerk_ eingestellt ist."
+
+#. Translators: Make sure to include the support article link as Markdown. See English text
+#: ../setup_flow.py:83
+msgid "Please see our support article for requirements, features and restrictions."
+msgstr "Bitte beachte unseren [Support-Artikel](https://support.unfoldedcircle.com/hc/en-us/articles/19479576638620) zu Anforderungen, unterstützten Funktionen und Einschränkungen."
+
+#: ../setup_flow.py:176
+msgid "Add a new device"
+msgstr "Neues Gerät hinzufügen"
+
+#: ../setup_flow.py:185
+msgid "Delete selected device"
+msgstr "Selektiertes Gerät löschen"
+
+#: ../setup_flow.py:191
+msgid "Configure selected device"
+msgstr "Selektiertes Gerät konfigurieren"
+
+#: ../setup_flow.py:197
+msgid "Reset configuration and reconfigure"
+msgstr "Konfiguration zurücksetzen und neu konfigurieren"
+
+#: ../setup_flow.py:205
+msgid "Configuration mode"
+msgstr "Konfigurations-Modus"
+
+#: ../setup_flow.py:210
+msgid "Configured devices"
+msgstr "Konfigurierte Geräte"
+
+#: ../setup_flow.py:215
+msgid "Action"
+msgstr "Aktion"
+
+#: ../setup_flow.py:289
+msgid "Manual MAC address (below)"
+msgstr "Manuelle MAC-Adresse (unten)"
+
+#: ../setup_flow.py:304
+msgid "MAC address"
+msgstr "MAC-Adresse"
+
+#: ../setup_flow.py:309
+msgid "Manual MAC address"
+msgstr "Manuelle MAC-Adress"
+
+#: ../setup_flow.py:314
+msgid "IP address (optional)"
+msgstr "IP-Adresse (optional)"
+
+#: ../setup_flow.py:386
+msgid "Please choose your Apple TV"
+msgstr "Bitte wähle deinen Apple TV"
+
+#: ../setup_flow.py:391
+msgid "Choose your Apple TV"
+msgstr "Wähle deinen Apple TV"
+
+#: ../setup_flow.py:453
+msgid "Please enter the shown AirPlay-Code on your Apple TV"
+msgstr "Bitte gib den angezeigten AirPlay-Code auf deinem Apple TV ein"
+
+#: ../setup_flow.py:458
+msgid "Apple TV AirPlay-Code"
+msgstr ""
+
+#: ../setup_flow.py:506
+msgid "Please enter the shown PIN on your Apple TV"
+msgstr "Bitte gib die angezeigte PIN auf deinem Apple TV ein"
+
+#: ../setup_flow.py:511
+msgid "Apple TV PIN"
+msgstr ""
+
+#: ../setup_flow.py:629
+#, fuzzy
+msgid "Setup mode"
+msgstr "Setup Fortschritt"
+
+#: ../setup_flow.py:633
+msgid "Discover or connect to Apple TV device"
+msgstr "Suche oder Verbinde auf Apple TV Gerät"
+
+#. Translators: Markdown can be used for formatting
+#: ../setup_flow.py:638
+msgid "Leave blank to use auto-discovery and click _Next_."
+msgstr "Leer lassen, um automatische Erkennung zu verwenden und auf _Weiter_ klicken."
+
+#: ../setup_flow.py:640
+#, fuzzy
+msgid "The device must be on the same network as the remote."
+msgstr "Das Gerät muss sich im gleichen Netzwerk wie die Fernbedienung befinden."
+
+#: ../setup_flow.py:647
+msgid "IP address (same network only)"
+msgstr "IP-Adresse (nur im gleichen Netzwerk)"
+
+#: ../setup_flow.py:657
+msgid "Change volume on all connected devices"
+msgstr "Lautstärkeregelung auf allen verbundenen Geräten"

--- a/intg-appletv/locales/de_DE/LC_MESSAGES/intg-appletv.po
+++ b/intg-appletv/locales/de_DE/LC_MESSAGES/intg-appletv.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: uc-integration-appletv\n"
+"Project-Id-Version: uc-integration-apple-tv\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-06-04 14:51+0200\n"
 "PO-Revision-Date: 2025-06-03 16:09\n"

--- a/intg-appletv/locales/en_US/LC_MESSAGES/intg-appletv.po
+++ b/intg-appletv/locales/en_US/LC_MESSAGES/intg-appletv.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: uc-integration-appletv\n"
+"Project-Id-Version: uc-integration-apple-tv\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-06-04 14:51+0200\n"
 "PO-Revision-Date: 2023-11-15 12:00+0000\n"

--- a/intg-appletv/locales/en_US/LC_MESSAGES/intg-appletv.po
+++ b/intg-appletv/locales/en_US/LC_MESSAGES/intg-appletv.po
@@ -28,8 +28,8 @@ msgstr "Integration setup"
 
 #: ../setup_flow.py:68
 #, fuzzy
-msgid "Setup proces"
-msgstr "Setup mode"
+msgid "Setup process"
+msgstr "Setup process"
 
 #: ../setup_flow.py:72
 msgid "The integration will discover your Apple TV on your network."

--- a/intg-appletv/locales/en_US/LC_MESSAGES/intg-appletv.po
+++ b/intg-appletv/locales/en_US/LC_MESSAGES/intg-appletv.po
@@ -1,0 +1,144 @@
+# English translations for Apple TV Integration.
+# Copyright (C) 2023 Unfolded Circle ApS
+# This file is distributed under the same license as the Apple TV Integration package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: uc-integration-appletv\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-04 14:51+0200\n"
+"PO-Revision-Date: 2023-11-15 12:00+0000\n"
+"Last-Translator: Unfolded Circle <hello@unfoldedcircle.com>\n"
+"Language-Team: English\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-SourceKey: msgstr\n"
+
+#: ../driver.py:717
+#, fuzzy
+msgid "Control your Apple TV with Remote Two/3."
+msgstr "Control your Apple TV with Remote Two/3."
+
+#: ../setup_flow.py:64
+msgid "Integration setup"
+msgstr "Integration setup"
+
+#: ../setup_flow.py:68
+#, fuzzy
+msgid "Setup proces"
+msgstr "Setup mode"
+
+#: ../setup_flow.py:72
+msgid "The integration will discover your Apple TV on your network."
+msgstr "The integration will discover your Apple TV on your network."
+
+#: ../setup_flow.py:75
+msgid "Apple TV 4 and newer are supported and the device must be on the same network as the remote."
+msgstr "Apple TV 4 and newer are supported and the device must be on the same network as the Remote."
+
+#: ../setup_flow.py:79
+msgid "During the process, you need to enter multiple PINs that are shown on your Apple TV. Please make sure to set AirPlay access to _Anyone on the Same Network_ in Apple TV settings."
+msgstr "During the process, you need to enter multiple PINs that are shown on your Apple TV. Please make sure to set AirPlay access to _Anyone on the Same Network_ in Apple TV settings."
+
+#. Translators: Make sure to include the support article link as Markdown. See English text
+#: ../setup_flow.py:83
+msgid "Please see our support article for requirements, features and restrictions."
+msgstr "Please see our [support article](https://support.unfoldedcircle.com/hc/en-us/articles/19479576638620) for requirements, features and restrictions."
+
+#: ../setup_flow.py:176
+msgid "Add a new device"
+msgstr "Add a new device"
+
+#: ../setup_flow.py:185
+msgid "Delete selected device"
+msgstr "Delete selected device"
+
+#: ../setup_flow.py:191
+msgid "Configure selected device"
+msgstr "Configure selected device"
+
+#: ../setup_flow.py:197
+msgid "Reset configuration and reconfigure"
+msgstr "Reset configuration and reconfigure"
+
+#: ../setup_flow.py:205
+msgid "Configuration mode"
+msgstr "Configuration mode"
+
+#: ../setup_flow.py:210
+msgid "Configured devices"
+msgstr "Configured devices"
+
+#: ../setup_flow.py:215
+msgid "Action"
+msgstr "Action"
+
+#: ../setup_flow.py:289
+msgid "Manual MAC address (below)"
+msgstr "Manual MAC address (below)"
+
+#: ../setup_flow.py:304
+msgid "MAC address"
+msgstr "MAC address"
+
+#: ../setup_flow.py:309
+msgid "Manual MAC address"
+msgstr "Manual MAC address"
+
+#: ../setup_flow.py:314
+msgid "IP address (optional)"
+msgstr "IP address (optional)"
+
+#: ../setup_flow.py:386
+msgid "Please choose your Apple TV"
+msgstr "Please choose your Apple TV"
+
+#: ../setup_flow.py:391
+msgid "Choose your Apple TV"
+msgstr "Choose your Apple TV"
+
+#: ../setup_flow.py:453
+msgid "Please enter the shown AirPlay-Code on your Apple TV"
+msgstr "Please enter the shown AirPlay-Code on your Apple TV"
+
+#: ../setup_flow.py:458
+msgid "Apple TV AirPlay-Code"
+msgstr "Apple TV AirPlay-Code"
+
+#: ../setup_flow.py:506
+msgid "Please enter the shown PIN on your Apple TV"
+msgstr "Please enter the shown PIN on your Apple TV"
+
+#: ../setup_flow.py:511
+msgid "Apple TV PIN"
+msgstr "Apple TV PIN"
+
+#: ../setup_flow.py:629
+#, fuzzy
+msgid "Setup mode"
+msgstr "Setup mode"
+
+#: ../setup_flow.py:633
+msgid "Discover or connect to Apple TV device"
+msgstr "Discover or connect to Apple TV device"
+
+#. Translators: Markdown can be used for formatting
+#: ../setup_flow.py:638
+msgid "Leave blank to use auto-discovery and click _Next_."
+msgstr "Leave blank to use auto-discovery and click _Next_."
+
+#: ../setup_flow.py:640
+#, fuzzy
+msgid "The device must be on the same network as the remote."
+msgstr "The device must be on the same network as the Remote."
+
+#: ../setup_flow.py:647
+msgid "IP address (same network only)"
+msgstr "IP address (same network only)"
+
+#: ../setup_flow.py:657
+msgid "Change volume on all connected devices"
+msgstr "Change volume on all connected devices"

--- a/intg-appletv/locales/fr_FR/LC_MESSAGES/intg-appletv.po
+++ b/intg-appletv/locales/fr_FR/LC_MESSAGES/intg-appletv.po
@@ -1,0 +1,138 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: uc-integration-appletv\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-04 14:51+0200\n"
+"PO-Revision-Date: 2025-06-03 16:09\n"
+"Last-Translator: Unfolded Circle <hello@unfoldedcircle.com>\n"
+"Language-Team: French\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-SourceKey: msgstr\n"
+
+#: ../driver.py:717
+msgid "Control your Apple TV with Remote Two/3."
+msgstr "Contrôler votre Apple TV avec Remote Two/3."
+
+#: ../setup_flow.py:64
+msgid "Integration setup"
+msgstr "Configuration de l'intégration"
+
+#: ../setup_flow.py:68
+msgid "Setup proces"
+msgstr "Progression de la configuration"
+
+#: ../setup_flow.py:72
+msgid "The integration will discover your Apple TV on your network."
+msgstr "L'intégration découvrira votre Apple TV sur votre réseau."
+
+#: ../setup_flow.py:75
+msgid "Apple TV 4 and newer are supported and the device must be on the same network as the remote."
+msgstr "Apple TV 4 et plus récentes sont prises en charge et l'appareil doit être sur le même réseau que la télécommande."
+
+#: ../setup_flow.py:79
+msgid "During the process, you need to enter multiple PINs that are shown on your Apple TV. Please make sure to set AirPlay access to _Anyone on the Same Network_ in Apple TV settings."
+msgstr "Au cours du processus, vous devez saisir plusieurs codes PIN qui s'affichent sur votre Apple TV. Veillez à ce que l'accès AirPlay soit réglé sur _Toute personne sur le même réseau_ dans les réglages de l'Apple TV."
+
+#. Translators: Make sure to include the support article link as Markdown. See English text
+#: ../setup_flow.py:83
+msgid "Please see our support article for requirements, features and restrictions."
+msgstr "Veuillez consulter [l’article de support](https://support.unfoldedcircle.com/hc/en-us/articles/19479576638620) pour connaître les exigences, les fonctionnalités prises en charge et les restrictions."
+
+#: ../setup_flow.py:176
+msgid "Add a new device"
+msgstr "Ajouter un nouvel appareil"
+
+#: ../setup_flow.py:185
+msgid "Delete selected device"
+msgstr "Supprimer l'appareil sélectionné"
+
+#: ../setup_flow.py:191
+msgid "Configure selected device"
+msgstr "Configurer l'appareil sélectionné"
+
+#: ../setup_flow.py:197
+msgid "Reset configuration and reconfigure"
+msgstr "Réinitialiser la configuration et reconfigurer"
+
+#: ../setup_flow.py:205
+msgid "Configuration mode"
+msgstr "Mode de configuration"
+
+#: ../setup_flow.py:210
+msgid "Configured devices"
+msgstr "Appareils configurés"
+
+#: ../setup_flow.py:215
+msgid "Action"
+msgstr ""
+
+#: ../setup_flow.py:289
+msgid "Manual MAC address (below)"
+msgstr "Adresse MAC manuelle (ci-dessous)"
+
+#: ../setup_flow.py:304
+msgid "MAC address"
+msgstr "Adresse MAC"
+
+#: ../setup_flow.py:309
+msgid "Manual MAC address"
+msgstr "Adresse MAC manuelle"
+
+#: ../setup_flow.py:314
+msgid "IP address (optional)"
+msgstr "Adresse IP (optionnelle)"
+
+#: ../setup_flow.py:386
+msgid "Please choose your Apple TV"
+msgstr "Choisissez votre Apple TV"
+
+#: ../setup_flow.py:391
+msgid "Choose your Apple TV"
+msgstr "Choisissez votre Apple TV"
+
+#: ../setup_flow.py:453
+msgid "Please enter the shown AirPlay-Code on your Apple TV"
+msgstr "Veuillez entrer le code AirPlay affiché sur votre Apple TV"
+
+#: ../setup_flow.py:458
+msgid "Apple TV AirPlay-Code"
+msgstr ""
+
+#: ../setup_flow.py:506
+msgid "Please enter the shown PIN on your Apple TV"
+msgstr "Veuillez entrer le code PIN affiché sur votre Apple TV"
+
+#: ../setup_flow.py:511
+msgid "Apple TV PIN"
+msgstr ""
+
+#: ../setup_flow.py:629
+#, fuzzy
+msgid "Setup mode"
+msgstr "Progression de la configuration"
+
+#: ../setup_flow.py:633
+msgid "Discover or connect to Apple TV device"
+msgstr "Découvrir ou connexion à l'appareil Apple TV"
+
+#. Translators: Markdown can be used for formatting
+#: ../setup_flow.py:638
+msgid "Leave blank to use auto-discovery and click _Next_."
+msgstr "Laissez le champ vide pour utiliser la découverte automatique et cliquez sur _Suivant_."
+
+#: ../setup_flow.py:640
+#, fuzzy
+msgid "The device must be on the same network as the remote."
+msgstr "L'appareil doit être sur le même réseau que la télécommande."
+
+#: ../setup_flow.py:647
+msgid "IP address (same network only)"
+msgstr "Adresse IP (seulement dans le même réseau)"
+
+#: ../setup_flow.py:657
+msgid "Change volume on all connected devices"
+msgstr "Régler le volume sur tous les appareils connectés"

--- a/intg-appletv/locales/fr_FR/LC_MESSAGES/intg-appletv.po
+++ b/intg-appletv/locales/fr_FR/LC_MESSAGES/intg-appletv.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: uc-integration-appletv\n"
+"Project-Id-Version: uc-integration-apple-tv\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-06-04 14:51+0200\n"
 "PO-Revision-Date: 2025-06-03 16:09\n"

--- a/intg-appletv/setup_flow.py
+++ b/intg-appletv/setup_flow.py
@@ -16,6 +16,7 @@ import discover
 import pyatv
 import tv
 from config import AtvDevice, AtvProtocol
+from i18n import __, _a, _af, _am
 from ucapi import (
     AbortDriverSetup,
     DriverSetupRequest,
@@ -47,51 +48,45 @@ class SetupSteps(IntEnum):
 _setup_step = SetupSteps.INIT
 _cfg_add_device: bool = False
 _manual_address: bool = False
-_discovered_atvs: list[pyatv.interface.BaseConfig] = None
+_discovered_atvs: list[pyatv.interface.BaseConfig] | None = None
 _pairing_apple_tv: tv.AppleTv | None = None
 _reconfigured_device: AtvDevice | None = None
-# TODO #12 externalize language texts
-# pylint: disable=line-too-long
-_user_input_discovery = RequestUserInput(
-    {"en": "Setup mode", "de": "Setup Modus"},
-    [
-        {
-            "id": "info",
-            "label": {
-                "en": "Discover or connect to Apple TV device",
-                "de": "Suche oder Verbinde auf Apple TV Gerät",
-                "fr": "Découvrir ou connexion à l'appareil Apple TV",
-            },
-            "field": {
-                "label": {
-                    "value": {
-                        "en": (
-                            "Leave blank to use auto-discovery and click _Next_."
-                            "The device must be on the same network as the remote."
-                        ),
-                        "de": (
-                            "Leer lassen, um automatische Erkennung zu verwenden und auf _Weiter_ klicken."
-                            "Das Gerät muss sich im gleichen Netzwerk wie die Fernbedienung befinden."
-                        ),
-                        "fr": (
-                            "Laissez le champ vide pour utiliser la découverte automatique et cliquez sur _Suivant_."
-                            "L'appareil doit être sur le même réseau que la télécommande"
-                        ),
+
+
+def setup_data_schema():
+    """
+    Get the JSON setup data structure for the driver.json file.
+
+    :return: ``setup_data_schema`` json object
+    """
+    # pylint: disable=line-too-long
+    return {
+        "title": _a("Integration setup"),
+        "settings": [
+            {
+                "id": "info",
+                "label": _a("Setup proces"),
+                "field": {
+                    "label": {
+                        "value": _am(
+                            __("The integration will discover your Apple TV on your network."),
+                            "\n",
+                            __(
+                                "Apple TV 4 and newer are supported and the device must be on the same network as the remote."
+                            ),
+                            "\n",
+                            __(
+                                "During the process, you need to enter multiple PINs that are shown on your Apple TV. Please make sure to set AirPlay access to _Anyone on the Same Network_ in Apple TV settings."
+                            ),
+                            "\n\n",
+                            # Translators: Make sure to include the support article link as Markdown. See English text
+                            __("Please see our support article for requirements, features and restrictions."),
+                        )
                     }
-                }
-            },
-        },
-        {
-            "field": {"text": {"value": ""}},
-            "id": "address",
-            "label": {
-                "en": "IP address (same network only)",
-                "de": "IP-Adresse (nur im gleichen Netzwerk)",
-                "fr": "Adresse IP (seulement dans le même réseau)",
-            },
-        },
-    ],
-)
+                },
+            }
+        ],
+    }
 
 
 async def driver_setup_handler(msg: SetupDriver) -> SetupAction:  # pylint: disable=too-many-return-statements
@@ -174,16 +169,11 @@ async def _handle_driver_setup(msg: DriverSetupRequest) -> RequestUserInput | Se
         for device in config.devices.all():
             dropdown_devices.append({"id": device.identifier, "label": {"en": f"{device.name} ({device.identifier})"}})
 
-        # TODO #12 externalize language texts
         # build user actions, based on available devices
         dropdown_actions = [
             {
                 "id": "add",
-                "label": {
-                    "en": "Add a new device",
-                    "de": "Neues Gerät hinzufügen",
-                    "fr": "Ajouter un nouvel appareil",
-                },
+                "label": _a("Add a new device"),
             },
         ]
 
@@ -192,31 +182,19 @@ async def _handle_driver_setup(msg: DriverSetupRequest) -> RequestUserInput | Se
             dropdown_actions.append(
                 {
                     "id": "remove",
-                    "label": {
-                        "en": "Delete selected device",
-                        "de": "Selektiertes Gerät löschen",
-                        "fr": "Supprimer l'appareil sélectionné",
-                    },
+                    "label": _a("Delete selected device"),
                 },
             )
             dropdown_actions.append(
                 {
                     "id": "configure",
-                    "label": {
-                        "en": "Configure selected device",
-                        "de": "Selektiertes Gerät konfigurieren",
-                        "fr": "Configurer l'appareil sélectionné",
-                    },
+                    "label": _a("Configure selected device"),
                 },
             )
             dropdown_actions.append(
                 {
                     "id": "reset",
-                    "label": {
-                        "en": "Reset configuration and reconfigure",
-                        "de": "Konfiguration zurücksetzen und neu konfigurieren",
-                        "fr": "Réinitialiser la configuration et reconfigurer",
-                    },
+                    "label": _a("Reset configuration and reconfigure"),
                 },
             )
         else:
@@ -224,25 +202,17 @@ async def _handle_driver_setup(msg: DriverSetupRequest) -> RequestUserInput | Se
             dropdown_devices.append({"id": "", "label": {"en": "---"}})
 
         return RequestUserInput(
-            {"en": "Configuration mode", "de": "Konfigurations-Modus", "fr": "Mode de configuration"},
+            _a("Configuration mode"),
             [
                 {
                     "field": {"dropdown": {"value": dropdown_devices[0]["id"], "items": dropdown_devices}},
                     "id": "choice",
-                    "label": {
-                        "en": "Configured devices",
-                        "de": "Konfigurierte Geräte",
-                        "fr": "Appareils configurés",
-                    },
+                    "label": _a("Configured devices"),
                 },
                 {
                     "field": {"dropdown": {"value": dropdown_actions[0]["id"], "items": dropdown_actions}},
                     "id": "action",
-                    "label": {
-                        "en": "Action",
-                        "de": "Aktion",
-                        "fr": "Appareils configurés",
-                    },
+                    "label": _a("Action"),
                 },
             ],
         )
@@ -250,7 +220,7 @@ async def _handle_driver_setup(msg: DriverSetupRequest) -> RequestUserInput | Se
     # Initial setup, make sure we have a clean configuration
     config.devices.clear()  # triggers device instance removal
     _setup_step = SetupSteps.DISCOVER
-    return _user_input_discovery
+    return __user_input_discovery()
 
 
 async def _handle_configuration_mode(msg: UserDataResponse) -> RequestUserInput | SetupComplete | SetupError:
@@ -295,7 +265,7 @@ async def _handle_configuration_mode(msg: UserDataResponse) -> RequestUserInput 
             discovered_atvs = await discover.apple_tvs(asyncio.get_event_loop())
             dropdown_items = []
 
-            # Found mac address/idenfitier of selected AppleTV upon detection
+            # Found mac address/identifier of selected AppleTV upon detection
             found_selected_device_id = ""
             for discovered_atv in discovered_atvs:
                 # List of detected AppleTVs : exclude already configured ones except the one the user selected
@@ -316,11 +286,7 @@ async def _handle_configuration_mode(msg: UserDataResponse) -> RequestUserInput 
             dropdown_items.append(
                 {
                     "id": "",
-                    "label": {
-                        "en": "Manual mac address (below)",
-                        "de": "Manuelle MAC-Adresse (unten)",
-                        "fr": "Adresse Mac manuelle (ci-dessous)",
-                    },
+                    "label": _a("Manual MAC address (below)"),
                 }
             )
 
@@ -330,48 +296,24 @@ async def _handle_configuration_mode(msg: UserDataResponse) -> RequestUserInput 
             address = selected_device.address if selected_device.address else ""
 
             return RequestUserInput(
-                {
-                    "en": "Configure your Apple TV (configured mac address " + mac_address + ")",
-                    "de": "Konfiguriere dein Apple TV (konfigurierte MAC-Adresse " + mac_address + ")",
-                    "fr": "Configurez votre Apple TV (addresse mac configurée " + mac_address + ")",
-                },
+                _af("Configure your Apple TV (configured mac address {mac_address})", mac_address=mac_address),
                 [
                     {
                         "field": {"dropdown": {"value": found_selected_device_id, "items": dropdown_items}},
                         "id": "mac_address",
-                        "label": {
-                            "en": "Mac address",
-                            "de": "Mac-Adresse",
-                            "fr": "Adresse Mac",
-                        },
+                        "label": _a("MAC address"),
                     },
                     {
                         "field": {"text": {"value": mac_address}},
                         "id": "manual_mac_address",
-                        "label": {
-                            "en": "Manual mac address",
-                            "de": "Manuelle MAC-Adresse",
-                            "fr": "Adresse Mac manuelle",
-                        },
+                        "label": _a("Manual MAC address"),
                     },
                     {
                         "field": {"text": {"value": address}},
                         "id": "address",
-                        "label": {
-                            "en": "IP address (optional)",
-                            "de": "IP-Adresse (optional)",
-                            "fr": "Adresse IP (optionnelle)",
-                        },
+                        "label": _a("IP address (optional)"),
                     },
-                    {
-                        "id": "global_volume",
-                        "label": {
-                            "en": "Change volume on all connected devices",
-                            "de": "Lautstärkeregelung auf allen verbundenen Geräten",
-                            "fr": "Régler le volume sur tous les appareils connectés",
-                        },
-                        "field": {"checkbox": {"value": True}},
-                    },
+                    __global_volume(True),
                 ],
             )
 
@@ -382,7 +324,7 @@ async def _handle_configuration_mode(msg: UserDataResponse) -> RequestUserInput 
             return SetupError(error_type=IntegrationSetupError.OTHER)
 
     _setup_step = SetupSteps.DISCOVER
-    return _user_input_discovery
+    return __user_input_discovery()
 
 
 async def _handle_discovery(msg: UserDataResponse) -> RequestUserInput | SetupError:
@@ -440,33 +382,20 @@ async def _handle_discovery(msg: UserDataResponse) -> RequestUserInput | SetupEr
         return SetupError(error_type=IntegrationSetupError.NOT_FOUND)
 
     _setup_step = SetupSteps.DEVICE_CHOICE
-    # TODO #12 externalize language texts
     return RequestUserInput(
-        {"en": "Please choose your Apple TV", "de": "Bitte wähle deinen Apple TV", "fr": "Choisissez votre Apple TV"},
+        _a("Please choose your Apple TV"),
         [
             {
                 "field": {"dropdown": {"value": dropdown_items[0]["id"], "items": dropdown_items}},
                 "id": "choice",
-                "label": {
-                    "en": "Choose your Apple TV",
-                    "de": "Wähle deinen Apple TV",
-                    "fr": "Choisissez votre Apple TV",
-                },
+                "label": _a("Choose your Apple TV"),
             },
-            {
-                "id": "global_volume",
-                "label": {
-                    "en": "Change volume on all connected devices",
-                    "de": "Lautstärkeregelung auf allen verbundenen Geräten",
-                    "fr": "Régler le volume sur tous les appareils connectés",
-                },
-                "field": {"checkbox": {"value": True}},
-            },
+            __global_volume(True),
         ],
     )
 
 
-async def _handle_device_choice(msg: UserDataResponse) -> RequestUserInput | SetupError:
+async def _handle_device_choice(msg: UserDataResponse) -> RequestUserInput | RequestUserConfirmation | SetupError:
     """
     Process user data device choice response in a setup process.
 
@@ -520,27 +449,24 @@ async def _handle_device_choice(msg: UserDataResponse) -> RequestUserInput | Set
     if res == 0:
         _LOG.debug("Device provides AirPlay-Code")
         _setup_step = SetupSteps.PAIRING_AIRPLAY
-        # TODO #12 externalize language texts
         return RequestUserInput(
-            {
-                "en": "Please enter the shown AirPlay-Code on your Apple TV",
-                "de": "Bitte gib die angezeigte AirPlay-Code auf deinem Apple TV ein",
-                "fr": "Veuillez entrer le code AirPlay affiché sur votre Apple TV",
-            },
+            _a("Please enter the shown AirPlay-Code on your Apple TV"),
             [
                 {
                     "field": {"number": {"max": 9999, "min": 0, "value": 0000}},
                     "id": "pin_airplay",
-                    "label": {"en": "Apple TV AirPlay-Code"},
+                    "label": _a("Apple TV AirPlay-Code"),
                 }
             ],
         )
 
     _LOG.debug("We provide AirPlay-Code")
-    return RequestUserConfirmation("Please enter the following PIN on your Apple TV: " + res)
+    return RequestUserConfirmation(_af("Please enter the following AirPlay-Code on your Apple TV: {pin}", pin=res))
 
 
-async def _handle_user_data_airplay_pin(msg: UserDataResponse) -> RequestUserInput | SetupError:
+async def _handle_user_data_airplay_pin(
+    msg: UserDataResponse,
+) -> RequestUserInput | RequestUserConfirmation | SetupError:
     """
     Process user data airplay pairing pin response in a setup process.
 
@@ -576,24 +502,19 @@ async def _handle_user_data_airplay_pin(msg: UserDataResponse) -> RequestUserInp
     if res == 0:
         _LOG.debug("Device provides PIN")
         _setup_step = SetupSteps.PAIRING_COMPANION
-        # TODO #12 externalize language texts
         return RequestUserInput(
-            {
-                "en": "Please enter the shown PIN on your Apple TV",
-                "de": "Bitte gib die angezeigte PIN auf deinem Apple TV ein",
-                "fr": "Veuillez entrer le code PIN affiché sur votre Apple TV",
-            },
+            _a("Please enter the shown PIN on your Apple TV"),
             [
                 {
                     "field": {"number": {"max": 9999, "min": 0, "value": 0000}},
                     "id": "pin_companion",
-                    "label": {"en": "Apple TV PIN"},
+                    "label": _a("Apple TV PIN"),
                 }
             ],
         )
 
     _LOG.debug("We provide companion PIN")
-    return RequestUserConfirmation("Please enter the following PIN on your Apple TV: " + res)
+    return RequestUserConfirmation(_af("Please enter the following companion PIN on your Apple TV: {pin}", pin=res))
 
 
 async def _handle_user_data_companion_pin(msg: UserDataResponse) -> SetupComplete | SetupError:
@@ -664,7 +585,7 @@ async def _handle_device_reconfigure(msg: UserDataResponse) -> SetupComplete | S
     global_volume = msg.input_values.get("global_volume", "true") == "true"
 
     if mac_address == "" and manual_mac_address == "":
-        _LOG.error("Mac address is mandatory, no changes applied")
+        _LOG.error("MAC address is mandatory, no changes applied")
         return SetupError()
     address = msg.input_values["address"]
     if address == "":
@@ -697,7 +618,44 @@ def _discovered_atv_from_identifier(identifier: str) -> pyatv.interface.BaseConf
     :param identifier: ATV identifier
     :return: Device configuration if found, None otherwise
     """
+    if _discovered_atvs is None:
+        return None
     for atv in _discovered_atvs:
         if atv.identifier == identifier:
             return atv
     return None
+
+
+def __user_input_discovery():
+    return RequestUserInput(
+        _a("Setup mode"),
+        [
+            {
+                "id": "info",
+                "label": _a("Discover or connect to Apple TV device"),
+                "field": {
+                    "label": {
+                        "value": _am(
+                            # Translators: Markdown can be used for formatting
+                            __("Leave blank to use auto-discovery and click _Next_."),
+                            "\n\n",
+                            __("The device must be on the same network as the remote."),
+                        )
+                    }
+                },
+            },
+            {
+                "id": "address",
+                "label": _a("IP address (same network only)"),
+                "field": {"text": {"value": ""}},
+            },
+        ],
+    )
+
+
+def __global_volume(enabled: bool):
+    return {
+        "id": "global_volume",
+        "label": _a("Change volume on all connected devices"),
+        "field": {"checkbox": {"value": enabled}},
+    }

--- a/intg-appletv/setup_flow.py
+++ b/intg-appletv/setup_flow.py
@@ -65,7 +65,7 @@ def setup_data_schema():
         "settings": [
             {
                 "id": "info",
-                "label": _a("Setup proces"),
+                "label": _a("Setup process"),
                 "field": {
                     "label": {
                         "value": _am(


### PR DESCRIPTION
Externalize all setup-flow language texts using Python gettext.
Provide helper functions for the expected language dictionaries in the Integration-API.

Use Crowdin with an automated translation process.
- For now only EN, FR, DE are included in the Pyinstaller build.
- More languages will be added once translated.
- Crowdin is setup to only export approved language texts

Closes #12 