### PR TITLE
refactor: adjust debug and info log levels for journald

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Changed
+- Adapt journald log levels until the Remote supports native debug levels.
+
 ---
 
 ## v0.20.1 - 2025-12-24

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -728,9 +728,11 @@ class JournaldFormatter(logging.Formatter):
         """Format the log record with journald priority prefix."""
         # mapping of logging levels to journald priority levels
         # https://www.freedesktop.org/software/systemd/man/latest/sd-daemon.html#syslog-compatible-log-levels
+        # Note: DEBUG app messages are logged with priority 6 (info) and INFO with priority 5 (notice)
+        # This is a workaround until the log subsystem on the Remote is updated to support debug levels.
         priority = {
-            logging.DEBUG: "<7>",
-            logging.INFO: "<6>",
+            logging.DEBUG: "<6>",  # SD_INFO
+            logging.INFO: "<5>",  # SD_NOTICE
             logging.WARNING: "<4>",
             logging.ERROR: "<3>",
             logging.CRITICAL: "<2>",


### PR DESCRIPTION
Log DEBUG app messages with priority 6 (info) and INFO with priority 5 (notice).
This is a workaround until the log subsystem on the Remote is updated to support debug levels.

Journal logging was introduced in #89. 
The previous console logging tagged everything with INFO level.