### PR TITLE
fix: create a custom driver.json for the custom driver archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,7 @@ jobs:
             bash -c \
             "cd /workspace && \
               python -m pip install -r requirements.txt && \
+              python intg-appletv/custom_driver.py && \
               pyinstaller --clean --onedir --name intg-appletv --add-data intg-appletv/locales:locales --collect-all zeroconf intg-appletv/driver.py"
           echo "Clean up locales"
           cd dist/intg-appletv/_internal/locales
@@ -91,8 +92,8 @@ jobs:
           mv dist/intg-appletv artifacts/
           mv artifacts/intg-appletv artifacts/bin
           mv artifacts/bin/intg-appletv artifacts/bin/driver
-          # patch metadata to not conflict with pre-installed driver
-          jq '.driver_id = "appletv_custom" | .name.en = "Apple TV custom"' driver.json > artifacts/driver.json
+          # use patched driver.json from the intg-appletv/custom_driver.py script above to not conflict with pre-installed driver
+          mv driver_custom.json artifacts/driver.json
           cp LICENSE artifacts/
           echo "ARTIFACT_NAME=uc-intg-${{ env.INTG_NAME }}-${{ env.VERSION }}-aarch64" >> $GITHUB_ENV
 

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ ENV/
 .DS_Store
 
 config.json
+driver_custom.json
 env
 licenses.json
 tools/licenses.md

--- a/intg-appletv/custom_driver.py
+++ b/intg-appletv/custom_driver.py
@@ -1,0 +1,23 @@
+"""
+Helper script to create a custom driver.json configuration in the build process.
+
+:copyright: (c) 2026 by Unfolded Circle ApS.
+:license: Mozilla Public License Version 2.0, see LICENSE for more details.
+"""
+
+import json
+from pathlib import Path
+
+from i18n import _a
+from setup_flow import setup_data_schema
+
+with open(Path(__file__).parent / ".." / "driver.json", "r", encoding="utf-8") as file:
+    driver_info = json.load(file)
+
+    driver_info["driver_id"] = "appletv_custom"
+    driver_info["name"]["en"] = "Apple TV custom"
+    driver_info["description"] = _a("Control your Apple TV with Remote Two/3.")
+    driver_info["setup_data_schema"] = setup_data_schema()
+
+    with open(Path(__file__).parent / ".." / "driver_custom.json", "w", encoding="utf-8") as f:
+        json.dump(driver_info, f, ensure_ascii=False, indent=2)

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -403,6 +403,7 @@ async def main():
 
     await api.init("driver.json", setup_flow.driver_setup_handler)
     # temporary hack to change driver.json language texts until supported by the wrapper lib
+    # Attention: keep in sync with `custom_config.py`!
     api._driver_info["description"] = _a("Control your Apple TV with Remote Two/3.")  # pylint: disable=W0212
     api._driver_info["setup_data_schema"] = setup_flow.setup_data_schema()  # pylint: disable=W0212
 


### PR DESCRIPTION
A custom integration driver archive requires a full driver.json file.
The locally installed driver and when running as an external integration driver used to create the driver information data dynamically.
For a custom integration driver this results in an empty main setup flow page, and a failed setup flow!