### PR TITLE
State handling refactor

### DIFF
--- a/.idea/integration-appletv.iml
+++ b/.idea/integration-appletv.iml
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _Changes in the next release_
 ### Fixed
 - Regression with tvOS 26.5 by @albaintor ([#110](https://github.com/unfoldedcircle/integration-appletv/pull/110)).
 - Create a valid driver.json file in the custom driver archive with custom driver_id and name ([#116](https://github.com/unfoldedcircle/integration-appletv/pull/116)).
+- Entity state is not updated if Apple TV device disconnects ([#93](https://github.com/unfoldedcircle/integration-appletv/issues/93)).
 
 ### Added
 - Add remote-entity by @albaintor ([#61](https://github.com/unfoldedcircle/integration-appletv/pull/61), [#115](https://github.com/unfoldedcircle/integration-appletv/pull/115)).
@@ -20,6 +21,7 @@ _Changes in the next release_
 - Refactored project structure for additional entity types by @albaintor ([#107](https://github.com/unfoldedcircle/integration-appletv/pull/107)).
 - Update ucapi to 0.6.0 ([#107](https://github.com/unfoldedcircle/integration-appletv/pull/107)).
 - Update pylint version ([#112](https://github.com/unfoldedcircle/integration-appletv/pull/112)).
+- State handling refactor for improved reliability and fallback if power state API is not available ([#120](https://github.com/unfoldedcircle/integration-appletv/pull/120)).
 
 ---
 

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -141,9 +141,11 @@ async def on_atv_connected(identifier: str) -> None:
     _LOG.debug("Apple TV connected: %s", identifier)
     state = media_player.States.UNKNOWN
     if identifier in _configured_atvs:
-        await on_atv_update(identifier, None)
+        await on_atv_update(
+            identifier, None
+        )  # TODO(#117) this will trigger entity_change events using the OLD entity attributes! What about entity state?
         await api.set_device_state(ucapi.DeviceStates.CONNECTED)  # just to make sure the device state is set
-        return
+        return  # TODO(#117) why return? Introduced in PR #107
 
     api.configured_entities.update_attributes(identifier, {media_player.Attributes.STATE: state})
     await api.set_device_state(ucapi.DeviceStates.CONNECTED)  # just to make sure the device state is set
@@ -152,6 +154,7 @@ async def on_atv_connected(identifier: str) -> None:
 async def on_atv_disconnected(identifier: str) -> None:
     """Handle ATV disconnection."""
     _LOG.debug("Apple TV disconnected: %s", identifier)
+    # TODO(#117) duplicated code with `on_atv_connection_error`
     for configured_entity in _get_entities(identifier):
         if configured_entity.entity_type == ucapi.EntityTypes.MEDIA_PLAYER:
             api.configured_entities.update_attributes(
@@ -213,10 +216,11 @@ def _get_entities(device_id: str, include_all=False) -> list[Entity]:
 # pylint: disable=too-many-branches,too-many-statements
 async def on_atv_update(device_id: str, update: dict[str, Any] | None) -> None:
     """
-    Update attributes of configured media-player entity if ATV properties changed.
+    Update attributes of all configured entities if ATV properties changed.
 
     :param device_id: ATV media-player entity identifier
-    :param update: dictionary containing the updated properties or None
+    :param update: dictionary containing the updated properties.
+                  ``None`` indicates that the last known entity attributes should be sent to the Remote.
     """
     if update is None:
         if device_id not in _configured_atvs:
@@ -235,6 +239,8 @@ async def on_atv_update(device_id: str, update: dict[str, Any] | None) -> None:
         elif isinstance(configured_entity, AppleTVRemote):
             attributes = configured_entity.filter_changed_attributes(update)
 
+        # TODO(#117) filter out unchanged properties to limit entity_change events. See Denon AVR implementation.
+        #            Otherwise there will be events every 10s triggered from the poller.
         if attributes:
             _LOG.debug("Updating attributes for entity %s : %s", configured_entity.id, truncate_dict(attributes))
             api.configured_entities.update_attributes(configured_entity.id, attributes)

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -139,16 +139,15 @@ async def on_unsubscribe_entities(entity_ids: list[str]) -> None:
 async def on_atv_connected(identifier: str) -> None:
     """Handle ATV connection."""
     _LOG.debug("Apple TV connected: %s", identifier)
-    state = media_player.States.UNKNOWN
-    if identifier in _configured_atvs:
-        await on_atv_update(
-            identifier, None
-        )  # TODO(#117) this will trigger entity_change events using the OLD entity attributes! What about entity state?
-        await api.set_device_state(ucapi.DeviceStates.CONNECTED)  # just to make sure the device state is set
-        return  # TODO(#117) why return? Introduced in PR #107
-
-    api.configured_entities.update_attributes(identifier, {media_player.Attributes.STATE: state})
     await api.set_device_state(ucapi.DeviceStates.CONNECTED)  # just to make sure the device state is set
+
+    if identifier in _configured_atvs:
+        atv = _configured_atvs[identifier]
+        state = atv.media_state
+        # make sure to not send an outdated state, not sure if media_state is immediately available
+        if state == tv.MediaState.UNAVAILABLE:
+            state = media_player.States.UNKNOWN
+        await on_atv_update(identifier, {media_player.Attributes.STATE: state})
 
 
 async def on_atv_disconnected(identifier: str) -> None:
@@ -286,9 +285,9 @@ def _register_available_entities(device_config: config.AtvDevice, device: tv.App
     """
     Add a new ATV device to the available entities.
 
-    :param identifier: ATV identifier
-    :param name: Friendly name
-    :return: True if added, False if the device was already in storage.
+    :param device_config: ATV device configuration
+    :param device: ATV device instance
+    :return: True if at least one device entity was added, False if all entities were already in storage.
     """
     media_player_entity = AppleTVMediaPlayer(device_config, device)
     entities: list[AppleTVEntity] = [

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -185,7 +185,6 @@ async def on_atv_connection_error(identifier: str, message) -> None:
             api.configured_entities.update_attributes(
                 configured_entity.id, {ucapi_remote.Attributes.STATE: ucapi_remote.States.UNAVAILABLE}
             )
-    await api.set_device_state(ucapi.DeviceStates.ERROR)
 
 
 def _get_entities(device_id: str, include_all=False) -> list[Entity]:

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -26,7 +26,6 @@ from i18n import _a
 from media_player import AppleTVMediaPlayer
 from remote import AppleTVRemote
 from ucapi import Entity, media_player
-from ucapi import remote as ucapi_remote
 from utils import filter_attributes, truncate_dict
 
 _LOG = logging.getLogger("driver")  # avoid having __main__ in log messages
@@ -150,41 +149,24 @@ async def on_atv_connected(identifier: str) -> None:
         await on_atv_update(identifier, {media_player.Attributes.STATE: state})
 
 
-async def on_atv_disconnected(identifier: str) -> None:
+def on_atv_disconnected(identifier: str) -> None:
     """Handle ATV disconnection."""
-    _LOG.debug("Apple TV disconnected: %s", identifier)
-    # TODO(#117) duplicated code with `on_atv_connection_error`
-    for configured_entity in _get_entities(identifier):
-        if configured_entity.entity_type == ucapi.EntityTypes.MEDIA_PLAYER:
-            api.configured_entities.update_attributes(
-                configured_entity.id, {ucapi.media_player.Attributes.STATE: ucapi.media_player.States.UNAVAILABLE}
-            )
-        elif configured_entity.entity_type == ucapi.EntityTypes.SENSOR:
-            api.configured_entities.update_attributes(
-                configured_entity.id, {ucapi.sensor.Attributes.STATE: ucapi.sensor.States.UNAVAILABLE}
-            )
-        elif configured_entity.entity_type == ucapi.EntityTypes.REMOTE:
-            api.configured_entities.update_attributes(
-                configured_entity.id, {ucapi_remote.Attributes.STATE: ucapi_remote.States.UNAVAILABLE}
-            )
+    _LOG.debug("[%s] Apple TV disconnected", identifier)
+    # The STATE attribute is common for all entities, just use the media player state value :-)
+    _set_all_entity_states(identifier, ucapi.media_player.States.UNAVAILABLE.value)
 
 
-async def on_atv_connection_error(identifier: str, message) -> None:
+def on_atv_connection_error(identifier: str, message) -> None:
     """Set entities of ATV to state UNAVAILABLE if ATV connection error occurred."""
-    _LOG.error(message)
+    _LOG.error("[%s] Apple TV connection error: %s", identifier, message)
+    _set_all_entity_states(identifier, ucapi.media_player.States.UNAVAILABLE.value)
+
+
+def _set_all_entity_states(identifier: str, state: str) -> None:
+    """Set the state of all entities of a device."""
     for configured_entity in _get_entities(identifier):
-        if configured_entity.entity_type == ucapi.EntityTypes.MEDIA_PLAYER:
-            api.configured_entities.update_attributes(
-                configured_entity.id, {ucapi.media_player.Attributes.STATE: ucapi.media_player.States.UNAVAILABLE}
-            )
-        elif configured_entity.entity_type == ucapi.EntityTypes.SENSOR:
-            api.configured_entities.update_attributes(
-                configured_entity.id, {ucapi.sensor.Attributes.STATE: ucapi.sensor.States.UNAVAILABLE}
-            )
-        elif configured_entity.entity_type == ucapi.EntityTypes.REMOTE:
-            api.configured_entities.update_attributes(
-                configured_entity.id, {ucapi_remote.Attributes.STATE: ucapi_remote.States.UNAVAILABLE}
-            )
+        # The STATE attribute is common for all entities, just use the media player state key :-)
+        api.configured_entities.update_attributes(configured_entity.id, {ucapi.media_player.Attributes.STATE: state})
 
 
 def _get_entities(device_id: str, include_all=False) -> list[Entity]:

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -223,11 +223,7 @@ async def on_atv_update(device_id: str, update: dict[str, Any] | None) -> None:
             return
         device = _configured_atvs[device_id]
         update = device.attributes
-    else:
-        _LOG.info("[%s] Device update: %s", device_id, truncate_dict(update))
 
-    # FIXME temporary workaround until ucapi has been refactored:
-    #       there's shouldn't be separate lists for available and configured entities
     for configured_entity in _get_entities(device_id):
         attributes = {}
         if isinstance(configured_entity, media_player.MediaPlayer):

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -239,7 +239,7 @@ async def on_atv_update(device_id: str, update: dict[str, Any] | None) -> None:
         elif isinstance(configured_entity, AppleTVRemote):
             attributes = configured_entity.filter_changed_attributes(update)
 
-        # TODO(#117) filter out unchanged properties to limit entity_change events. See Denon AVR implementation.
+        # TODO(#118) filter out unchanged properties to limit entity_change events. See Denon AVR implementation.
         #            Otherwise there will be events every 10s triggered from the poller.
         if attributes:
             _LOG.debug("Updating attributes for entity %s : %s", configured_entity.id, truncate_dict(attributes))

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -150,23 +150,24 @@ async def on_atv_connected(identifier: str) -> None:
 
 
 def on_atv_disconnected(identifier: str) -> None:
-    """Handle ATV disconnection."""
+    """Handle ATV disconnection. Set all entities to the UNAVAILABLE state."""
     _LOG.debug("[%s] Apple TV disconnected", identifier)
-    # The STATE attribute is common for all entities, just use the media player state value :-)
-    _set_all_entity_states(identifier, ucapi.media_player.States.UNAVAILABLE.value)
+    _set_all_entities_to_unavailable(identifier)
 
 
 def on_atv_connection_error(identifier: str, message) -> None:
     """Set entities of ATV to state UNAVAILABLE if ATV connection error occurred."""
     _LOG.error("[%s] Apple TV connection error: %s", identifier, message)
-    _set_all_entity_states(identifier, ucapi.media_player.States.UNAVAILABLE.value)
+    _set_all_entities_to_unavailable(identifier)
 
 
-def _set_all_entity_states(identifier: str, state: str) -> None:
-    """Set the state of all entities of a device."""
+def _set_all_entities_to_unavailable(identifier: str) -> None:
+    """Set all entities of a device to state UNAVAILABLE."""
     for configured_entity in _get_entities(identifier):
-        # The STATE attribute is common for all entities, just use the media player state key :-)
-        api.configured_entities.update_attributes(configured_entity.id, {ucapi.media_player.Attributes.STATE: state})
+        # The STATE attribute is common for all entities, just use the media player state :-)
+        api.configured_entities.update_attributes(
+            configured_entity.id, {ucapi.media_player.Attributes.STATE: ucapi.media_player.States.UNAVAILABLE.value}
+        )
 
 
 def _get_entities(device_id: str, include_all=False) -> list[Entity]:

--- a/intg-appletv/media_player.py
+++ b/intg-appletv/media_player.py
@@ -166,24 +166,21 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
         # pylint: disable=R0912,R0915
         _LOG.info("Got %s command request: %s %s", self.id, cmd_id, params if params else "")
 
-        # If the entity is OFF (device is in standby), we turn it on regardless of the actual command
-        if self._device.is_on is None or self._device.is_on is False:
-            _LOG.debug("Device not connected, reconnect")
+        # #117: If the device is not connected, but we get a command: try to connect.
+        if not self._device.is_enabled:
+            _LOG.warning("Received a command, but device is not active: reconnect")
             await self._device.connect()
 
+        # TODO(#117) verify state check
         state = self._device.media_state
-
-        # TODO #15 implement proper fix for correct entity OFF state (it may not remain in OFF state if connection is
-        #  established) + online check if we think it is in standby mode.
         if state == media_player.States.OFF and cmd_id not in (Commands.OFF, Commands.TOGGLE):
             _LOG.debug("Device is off, sending turn on command")
-            # quick & dirty workaround for #15: the entity state is not always correct!
             res = await self._device.turn_on()
             if res != StatusCodes.OK:
                 return res
 
-        # Only proceed if self._device connection is established
-        if self._device.is_on is False:
+        # Only proceed if device connection is enabled
+        if not self._device.is_enabled:
             return StatusCodes.SERVICE_UNAVAILABLE
 
         res = StatusCodes.BAD_REQUEST
@@ -216,11 +213,11 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
             case Commands.OFF:
                 res = await self._device.turn_off()
             case Commands.TOGGLE:
-                # pylint: disable=W0212
-                if self._device.is_on:
-                    res = await self._device.turn_off()
-                else:
+                # TODO(#117) check power state. If power state is not available use local assumed state
+                if state == media_player.States.OFF:
                     res = await self._device.turn_on()
+                else:
+                    res = await self._device.turn_off()
             case Commands.CURSOR_UP:
                 res = await self._device.cursor_up()
             case Commands.CURSOR_DOWN:

--- a/intg-appletv/media_player.py
+++ b/intg-appletv/media_player.py
@@ -14,6 +14,7 @@ import tv
 from config import AppleTVEntity, AtvDevice
 from hid import UsagePage
 from hid.consumer_control_code import ConsumerControlCode
+from pyatv.const import PowerState
 from ucapi import MediaPlayer, StatusCodes, media_player
 from ucapi.media_player import (
     Attributes,
@@ -71,6 +72,9 @@ def _get_cmd_param(name: str, params: dict[str, Any] | None) -> str | bool | Non
 
 class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
     """Representation of a AppleTV Media Player entity."""
+
+    _assumed_state: media_player.States = media_player.States.OFF
+    """Fallback state if device power state is not available."""
 
     def __init__(self, config_device: AtvDevice, device: tv.AppleTv):
         """Initialize the class."""
@@ -171,7 +175,7 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
             _LOG.warning("Received a command, but device is not active: reconnect")
             await self._device.connect()
 
-        # TODO(#117) verify state check
+        # TODO(#117) verify state check: bail out on media_player.States.UNAVAILABLE or best effort?
         state = self._device.media_state
         if state == media_player.States.OFF and cmd_id not in (Commands.OFF, Commands.TOGGLE):
             _LOG.debug("Device is off, sending turn on command")
@@ -213,7 +217,18 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
             case Commands.OFF:
                 res = await self._device.turn_off()
             case Commands.TOGGLE:
-                # TODO(#117) check power state. If power state is not available use local assumed state
+                # #117 If power state is not available use local assumed state (random pyatv bug)
+                if self._device.power_state == PowerState.Unknown:
+                    _LOG.warning(
+                        "Power state is not available for toggle, using assumed state: %s", self._assumed_state
+                    )
+                    state = self._assumed_state
+                    self._assumed_state = (
+                        media_player.States.OFF
+                        if self._assumed_state == media_player.States.ON
+                        else media_player.States.ON
+                    )
+
                 if state == media_player.States.OFF:
                     res = await self._device.turn_on()
                 else:

--- a/intg-appletv/media_player.py
+++ b/intg-appletv/media_player.py
@@ -73,13 +73,12 @@ def _get_cmd_param(name: str, params: dict[str, Any] | None) -> str | bool | Non
 class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
     """Representation of a AppleTV Media Player entity."""
 
-    _assumed_state: media_player.States = media_player.States.OFF
-    """Fallback state if device power state is not available."""
-
     def __init__(self, config_device: AtvDevice, device: tv.AppleTv):
         """Initialize the class."""
         # pylint: disable = R0801
         self._device = device
+        self._assumed_state: media_player.States = media_player.States.OFF
+        """Fallback state if device power state is not available."""
         # entity_id = create_entity_id(config_device.name, EntityTypes.MEDIA_PLAYER)
         entity_id = config_device.identifier
         features = [
@@ -185,10 +184,6 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
             res = await self._device.turn_on()
             if res != StatusCodes.OK:
                 return res
-
-        # Only proceed if device connection is enabled
-        if not self._device.is_enabled:
-            return StatusCodes.SERVICE_UNAVAILABLE
 
         res = StatusCodes.BAD_REQUEST
 

--- a/intg-appletv/media_player.py
+++ b/intg-appletv/media_player.py
@@ -170,12 +170,15 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
         # pylint: disable=R0912,R0915
         _LOG.info("Got %s command request: %s %s", self.id, cmd_id, params if params else "")
 
-        # #117: If the device is not connected, but we get a command: try to connect.
+        # #117: If the device is not connected, but we get a command: try to connect. Should not happen...
+        # Note: we don't check on entity state `UNAVAILABLE`:
+        # - the remote _should not_ send a command if the entity is unavailable
+        # - if something is out of sync: best effort mode. If ATV is not reachable: 503 is returned
         if not self._device.is_enabled:
             _LOG.warning("Received a command, but device is not active: reconnect")
             await self._device.connect()
 
-        # TODO(#117) verify state check: bail out on media_player.States.UNAVAILABLE or best effort?
+        # Automatically wake ATV from standby if a command is received
         state = self._device.media_state
         if state == media_player.States.OFF and cmd_id not in (Commands.OFF, Commands.TOGGLE):
             _LOG.debug("Device is off, sending turn on command")
@@ -249,7 +252,7 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
                 res = await self._device.fast_forward()
             case Commands.REPEAT:
                 mode = _get_cmd_param("repeat", params)
-                res = await self._device.set_repeat(mode) if mode else StatusCodes.BAD_REQUEST
+                res = await self._device.set_repeat(mode) if isinstance(mode, str) else StatusCodes.BAD_REQUEST
             case Commands.SHUFFLE:
                 mode = _get_cmd_param("shuffle", params)
                 res = await self._device.set_shuffle(mode) if isinstance(mode, bool) else StatusCodes.BAD_REQUEST
@@ -288,7 +291,7 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
                 res = await self._device.rewind_companion()
             case Commands.SELECT_SOUND_MODE:
                 mode = _get_cmd_param("mode", params)
-                res = await self._device.set_output_device(mode)
+                res = await self._device.set_output_device(mode) if isinstance(mode, str) else StatusCodes.BAD_REQUEST
             case Commands.SEEK:
                 res = await self._device.set_media_position(params.get("media_position", 0))
             case SimpleCommands.SWIPE_LEFT:
@@ -304,4 +307,4 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
             case SimpleCommands.PAUSE:
                 res = await self._device.pause()
 
-        return res
+        return res if res is not None else StatusCodes.SERVER_ERROR

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -15,6 +15,7 @@ import hashlib
 import itertools
 import logging
 import random
+import re
 from asyncio import AbstractEventLoop, Task
 from collections import OrderedDict
 from enum import Enum, StrEnum
@@ -404,16 +405,16 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         return self._connection_attempts * BACKOFF_SEC
 
     def playstatus_update(self, _updater, playstatus: pyatv.interface.Playing) -> None:
-        """Play status push update callback handler."""
-        _LOG.debug("[%s] Push update: %s", self.log_id, str(playstatus))
+        """Play status push update callback handler (push_updater.listener)."""
+        if _LOG.isEnabledFor(logging.DEBUG):
+            _LOG.debug("[%s] Push update: %s", self.log_id, re.sub(r"\n\s*", ", ", str(playstatus)))
         _ = asyncio.ensure_future(self._process_update(playstatus))
 
     def playstatus_error(self, _updater, exception: Exception) -> None:
-        """Play status push update error callback handler."""
+        """Play status push update error callback handler (push_updater.listener)."""
         _LOG.warning("[%s] A %s error occurred: %s", self.log_id, exception.__class__, exception)
         data = pyatv.interface.Playing()
         _ = asyncio.ensure_future(self._process_update(data))
-        # TODO restart push updates?
 
     def connection_lost(self, exception) -> None:
         """
@@ -433,7 +434,8 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         self._handle_disconnect()
 
     def _handle_disconnect(self):
-        """Handle that the device disconnected and restart connect loop."""
+        """Handle that the device disconnected and restart the connection loop."""
+        self.events.emit(EVENTS.DISCONNECTED, self._device.identifier)
         _ = asyncio.ensure_future(self._stop_polling())
         if self._atv:
             self._atv.close()
@@ -749,8 +751,6 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             update[MediaAttr.SHUFFLE] = self._shuffle
 
     async def _process_update(self, data: pyatv.interface.Playing) -> None:  # pylint: disable=too-many-branches
-        _LOG.debug("[%s] Process update", self.log_id)
-
         # store current state: used in `media_state` property
         self._state = data.device_state
 

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -231,7 +231,8 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         """Create instance."""
         self._loop: AbstractEventLoop = loop or asyncio.get_running_loop()
         self.events = AsyncIOEventEmitter(self._loop)
-        self._is_on: bool = False
+        self._is_enabled: bool = False
+        """Keep the ATV connection alive."""
         self._atv: pyatv.interface.AppleTV | None = None
         if device.credentials is None:
             device.credentials = []
@@ -289,16 +290,19 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         """Return the optional device address."""
         return self._device.address
 
+    # TODO(#117) verify if this method is used correctly. It's a confusing connected vs "powered on" logic!
+    #      The device can be connected, but in standby!
     @property
     def is_on(self) -> bool | None:
         """Whether the Apple TV is on or off. Returns None if not connected."""
         if self._atv is None:
             return None
 
-        if self._atv.power.power_state == PowerState.On and self._is_on is False:
-            self._is_on = True
+        # Unfortunately, we can't trust the power API; there are random connect issues: https://github.com/postlund/pyatv/issues/2823
+        if self._atv.power.power_state != PowerState.Unknown:
+            return self._atv.power.power_state == PowerState.On
 
-        return self._is_on
+        return self._is_enabled
 
     @property
     def state(self) -> DeviceState | None:
@@ -539,26 +543,26 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
 
     async def connect(self) -> None:
         """Establish connection to ATV."""
-        if self._is_on is True:
+        if self._is_enabled:
             return
-        self._is_on = True
+        self._is_enabled = True
         self._start_connect_loop()
 
     def _start_connect_loop(self) -> None:
-        if not self._connect_task and self._atv is None and self._is_on:
+        if not self._connect_task and self._atv is None and self._is_enabled:
             self.events.emit(EVENTS.CONNECTING, self._device.identifier)
             self._connect_task = asyncio.create_task(self._connect_loop())
         else:
             _LOG.debug(
-                "[%s] Not starting connect loop (ATv: %s, isOn: %s)",
+                "[%s] Not starting connect loop (ATV: %s, enabled: %s)",
                 self.log_id,
                 self._atv is None,
-                self._is_on,
+                self._is_enabled,
             )
 
     async def _connect_loop(self) -> None:
         _LOG.debug("[%s] Starting connect loop", self.log_id)
-        while self._is_on and self._atv is None:
+        while self._is_enabled and self._atv is None:
             await self._connect_once()
             if self._atv is not None:
                 break
@@ -661,7 +665,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
     async def disconnect(self) -> None:
         """Disconnect from ATV."""
         _LOG.debug("[%s] Disconnecting from device", self.log_id)
-        self._is_on = False
+        self._is_enabled = False
         await self._stop_polling()
 
         try:

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -81,12 +81,16 @@ ERROR_OS_WAIT = 0.5
 class EVENTS(StrEnum):
     """Internal driver events."""
 
-    CONNECTING = "CONNECTING"
+    CONNECTING = "CONNECTING"  # TODO emitted, but no handler
+    """Device connecting event. Parameter: device identifier."""
     CONNECTED = "CONNECTED"
+    """Device connected event. Parameter: device identifier."""
     DISCONNECTED = "DISCONNECTED"
-    PAIRED = "PAIRED"
+    """Device disconnected event. Parameter: device identifier."""
     ERROR = "ERROR"
+    """Device error event. Parameters: device identifier, error message."""
     UPDATE = "UPDATE"
+    """Device update event. Parameters: device identifier, update data dict."""
 
 
 _AppleTvT = TypeVar("_AppleTvT", bound="AppleTv")
@@ -411,13 +415,13 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         _ = asyncio.ensure_future(self._process_update(data))
         # TODO restart push updates?
 
-    def connection_lost(self, _exception) -> None:
+    def connection_lost(self, exception) -> None:
         """
         Device was unexpectedly disconnected.
 
         This is a callback function from pyatv.interface.DeviceListener.
         """
-        _LOG.exception("[%s] Lost connection %s", self.log_id, _exception)
+        _LOG.warning("[%s] Lost connection: %s", self.log_id, exception)
         self._handle_disconnect()
 
     def connection_closed(self) -> None:
@@ -678,7 +682,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
     async def _start_polling(self) -> None:
         if self._atv is None:
             _LOG.warning("[%s] Polling not started, AppleTv object is None", self.log_id)
-            self.events.emit(EVENTS.ERROR, "Polling not started, AppleTv object is None")
+            self.events.emit(EVENTS.ERROR, self._device.identifier, "Polling not started, AppleTv object is None")
             return
 
         self._polling = self._loop.create_task(self._poll_worker())

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -687,8 +687,8 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             self.events.emit(EVENTS.ERROR, self._device.identifier, "Polling not started, AppleTv object is None")
             return
 
+        _LOG.debug("[%s] Starting polling task", self.log_id)
         self._polling = self._loop.create_task(self._poll_worker())
-        _LOG.debug("[%s] Polling started", self.log_id)
 
     async def _stop_polling(self) -> None:
         if self._polling:
@@ -861,6 +861,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
 
     async def _poll_worker(self) -> None:
         await asyncio.sleep(2)
+        _LOG.debug("[%s] Polling started with interval %ds", self.log_id, self._poll_interval)
         while self._atv is not None:
             update = {}
 
@@ -879,6 +880,8 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
                     await self._process_artwork(update, None)
             except pyatv.exceptions.NotSupportedError:
                 pass
+            except Exception as ex:  # pylint: disable=broad-except
+                _LOG.error("[%s] Polling error: %s", self.log_id, ex)
 
             # #117: Keep it simple: we can't reliably determine the old state.
             #       The on_atv_update event receiver will filter out unchanged entity attributes
@@ -886,6 +889,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
 
             await asyncio.sleep(self._poll_interval)
+        _LOG.debug("[%s] Polling task stopped", self.log_id)
 
     @property
     def power_state(self) -> PowerState:

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -290,28 +290,16 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         """Return the optional device address."""
         return self._device.address
 
-    # TODO(#117) verify if this method is used correctly. It's a confusing connected vs "powered on" logic!
-    #      The device can be connected, but in standby!
     @property
-    def is_on(self) -> bool | None:
-        """Whether the Apple TV is on or off. Returns None if not connected."""
-        if self._atv is None:
-            return None
-
-        # Unfortunately, we can't trust the power API; there are random connect issues:
-        # https://github.com/postlund/pyatv/issues/2823
-        power_state = self._get_power_state()
-        if power_state != PowerState.Unknown:
-            return power_state == PowerState.On
-
+    def is_enabled(self):
+        """Return whether the device is enabled."""
         return self._is_enabled
 
     @property
     def media_state(self) -> MediaState:
         """Return the media-player state."""
         # DeviceState does not contain an OFF state: check power state first
-        power_state = self._get_power_state()
-        if power_state == PowerState.Off:
+        if self.power_state == PowerState.Off:
             return MediaState.OFF
 
         # Starting up, set to unavailable
@@ -891,7 +879,8 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
 
             await asyncio.sleep(self._poll_interval)
 
-    def _get_power_state(self) -> PowerState:
+    @property
+    def power_state(self) -> PowerState:
         """
         Get the current power state of the device.
 

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -1252,7 +1252,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         """Set output device selection."""
         if device_name is None:
             return StatusCodes.BAD_REQUEST
-        device_entry = self._output_devices.get(device_name, [])
+        device_entry = self._output_devices.get(device_name)
         if device_entry is None:
             _LOG.warning(
                 "Output device not found in the list %s (list : %s)", device_name, self.output_devices_combinations

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -307,11 +307,6 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         return self._is_enabled
 
     @property
-    def state(self) -> DeviceState | None:
-        """Return the device state."""
-        return self._state
-
-    @property
     def media_state(self) -> MediaState:
         """Return the media-player state."""
         if self._state is None:

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -301,21 +301,24 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
 
         # Unfortunately, we can't trust the power API; there are random connect issues:
         # https://github.com/postlund/pyatv/issues/2823
-        if self._atv.power.power_state != PowerState.Unknown:
-            return self._atv.power.power_state == PowerState.On
+        power_state = self._get_power_state()
+        if power_state != PowerState.Unknown:
+            return power_state == PowerState.On
 
         return self._is_enabled
 
     @property
     def media_state(self) -> MediaState:
         """Return the media-player state."""
-        if self._state is None:
+        # DeviceState does not contain an OFF state: check power state first
+        power_state = self._get_power_state()
+        if power_state == PowerState.Off:
             return MediaState.OFF
-        # FIXME(#117) mixed up state handling: rewrite
-        # if isinstance(self._state, PowerState):
-        #     if self._state == PowerState.Off:
-        #         return MediaState.OFF
-        #     return MediaState.ON
+
+        # Starting up, set to unavailable
+        if self._state is None:
+            return MediaState.UNAVAILABLE
+
         return MEDIA_STATE_MAPPING.get(self._state, MediaState.UNKNOWN)
 
     @property
@@ -749,20 +752,10 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
     async def _process_update(self, data: pyatv.interface.Playing) -> None:  # pylint: disable=too-many-branches
         _LOG.debug("[%s] Process update", self.log_id)
 
-        update = {}
-        power_state = await self._get_power_state()
-        # off state is not included in metadata, don't override it
-        current_state = self.media_state
-        # FIXME(#117) _state is NOT PowerState: rewrite!
-        # if power_state and power_state == PowerState.Off:
-        #     self._state = PowerState.Off
-        # else:
-        #     self._state = data.device_state
-        if power_state != PowerState.Off:
-            self._state = data.device_state
+        # store current state: used in `media_state` property
+        self._state = data.device_state
 
-        if current_state != self.media_state:
-            update[MediaAttr.STATE] = self.media_state
+        update = {MediaAttr.STATE: self.media_state}
 
         reset_playback_info = self._state not in [
             DeviceState.Playing,
@@ -871,11 +864,6 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         await asyncio.sleep(2)
         while self._atv is not None:
             update = {}
-            current_state = self.media_state
-            power_state = await self._get_power_state()
-            # FIXME(#117) _state is NOT PowerState: rewrite!
-            # if power_state and power_state == PowerState.Off:
-            #     self._state = PowerState.Off
 
             if self._is_feature_available(FeatureName.App) and self._atv.metadata.app.name:
                 update[MediaAttr.SOURCE] = self._atv.metadata.app.name
@@ -884,29 +872,31 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
 
             if data := await self._atv.metadata.playing():
                 await self._analyze_updated_data(update, data)
-
-                # off state is not included in metadata, don't override it
-                if power_state and power_state != PowerState.Off:
-                    self._state = data.device_state
+                self._state = data.device_state
             else:
                 # No playback data available, clear the artwork
                 await self._process_artwork(update, None)
 
-            if current_state != self.media_state:
-                update[MediaAttr.STATE] = self.media_state
+            # TODO(#117) current state logic was broken. Always set state for a quick fix.
+            #            We might have to store the last state since it can't be accurately recalculated!
+            update[MediaAttr.STATE] = self.media_state
 
             if update:
                 self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
 
             await asyncio.sleep(self._poll_interval)
 
-    async def _get_power_state(self) -> PowerState | None:
-        # Push updates are not reliable for power events, and if the device is in standby it reports state idle!
-        if self._is_feature_available(FeatureName.PowerState):
-            # Off isn't sent with push updates with the current pyatv library
-            # Care must be taken to not override certain states like playing and paused
+    def _get_power_state(self) -> PowerState:
+        """
+        Get the current power state of the device.
+
+        :return: The power state or PowerState.Unknown if not available.
+        """
+        # Take special care accessing power state: it might not be available depending on protocol,
+        # or if the device is not connected
+        if self._atv and self._is_feature_available(FeatureName.PowerState):
             return self._atv.power.power_state
-        return None
+        return PowerState.Unknown
 
     async def _process_artwork(self, update: dict[Any, Any], data: pyatv.interface.Playing | None):
         current_media_image_url = self._media_image_url

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -120,7 +120,6 @@ MEDIA_TYPE_MAPPING = {
 REPEAT_MAPPING = {RepeatState.Off: RepeatMode.OFF, RepeatState.All: RepeatMode.ALL, RepeatState.Track: RepeatMode.ONE}
 
 
-# TODO rename confusing function name: nothing to do with debouncing, this is a deferred function call
 def debounce(wait: float):
     """Debounce function with delay in seconds."""
 
@@ -350,10 +349,14 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
 
     @property
     def app_name(self) -> str:
-        """Return current app name."""
+        """Return the current app name."""
         app_name = ""
-        if self._atv and self._atv.metadata and self._atv.metadata.app:
-            app_name = self._atv.metadata.app.name
+        if self._atv and self._is_feature_available(FeatureName.App) and self._atv.metadata:
+            app = self._atv.metadata.app
+            if app:
+                app_name = app.name
+                if app_name is None:
+                    app_name = ""
         return app_name
 
     @property
@@ -865,24 +868,26 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         while self._atv is not None:
             update = {}
 
-            if self._is_feature_available(FeatureName.App) and self._atv.metadata.app.name:
-                update[MediaAttr.SOURCE] = self._atv.metadata.app.name
-                update[AppleTVSelects.SELECT_APP] = {SelectAttributes.CURRENT_OPTION: self.app_name}
-                update[AppleTVSensors.SENSOR_APP] = self.app_name
+            app_name = self.app_name
+            if app_name:
+                update[MediaAttr.SOURCE] = app_name
+                update[AppleTVSelects.SELECT_APP] = {SelectAttributes.CURRENT_OPTION: app_name}
+                update[AppleTVSensors.SENSOR_APP] = app_name
 
-            if data := await self._atv.metadata.playing():
-                await self._analyze_updated_data(update, data)
-                self._state = data.device_state
-            else:
-                # No playback data available, clear the artwork
-                await self._process_artwork(update, None)
+            try:
+                if data := await self._atv.metadata.playing():
+                    await self._analyze_updated_data(update, data)
+                    self._state = data.device_state
+                else:
+                    # No playback data available, clear the artwork
+                    await self._process_artwork(update, None)
+            except pyatv.exceptions.NotSupportedError:
+                pass
 
-            # TODO(#117) current state logic was broken. Always set state for a quick fix.
-            #            We might have to store the last state since it can't be accurately recalculated!
+            # #117: Keep it simple: we can't reliably determine the old state.
+            #       The on_atv_update event receiver will filter out unchanged entity attributes
             update[MediaAttr.STATE] = self.media_state
-
-            if update:
-                self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
+            self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
 
             await asyncio.sleep(self._poll_interval)
 

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -435,11 +435,12 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
 
     def _handle_disconnect(self):
         """Handle that the device disconnected and restart the connection loop."""
-        self.events.emit(EVENTS.DISCONNECTED, self._device.identifier)
         _ = asyncio.ensure_future(self._stop_polling())
         if self._atv:
             self._atv.close()
             self._atv = None
+        # make sure the DISCONNECTED listener is sync to avoid any race conditions!
+        self.events.emit(EVENTS.DISCONNECTED, self._device.identifier)
         self._start_connect_loop()
 
     def _volume_notify(self):

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -238,7 +238,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         self._loop: AbstractEventLoop = loop or asyncio.get_running_loop()
         self.events = AsyncIOEventEmitter(self._loop)
         self._is_enabled: bool = False
-        """Keep the ATV connection alive."""
+        """Determine if the ATV connection should be kept alive."""
         self._atv: pyatv.interface.AppleTV | None = None
         if device.credentials is None:
             device.credentials = []
@@ -249,7 +249,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         self._pairing_process: pyatv.interface.PairingHandler | None = None
         self._polling = None
         self._poll_interval: int = 10
-        self._state: DeviceState | None = None
+        self._device_state: DeviceState | None = None
         self._app_list: dict[str, str] = {}
         self._available_output_devices: dict[str, str] = {}
         self._output_devices: OrderedDict[str, list[str]] = OrderedDict[str, list[str]]()
@@ -309,10 +309,10 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             return MediaState.OFF
 
         # Starting up, set to unavailable
-        if self._state is None:
+        if self._device_state is None:
             return MediaState.UNAVAILABLE
 
-        return MEDIA_STATE_MAPPING.get(self._state, MediaState.UNKNOWN)
+        return MEDIA_STATE_MAPPING.get(self._device_state, MediaState.UNKNOWN)
 
     @property
     def media_content_type(self) -> MediaContentType:
@@ -752,11 +752,11 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
 
     async def _process_update(self, data: pyatv.interface.Playing) -> None:  # pylint: disable=too-many-branches
         # store current state: used in `media_state` property
-        self._state = data.device_state
+        self._device_state = data.device_state
 
         update = {MediaAttr.STATE: self.media_state}
 
-        reset_playback_info = self._state not in [
+        reset_playback_info = self._device_state not in [
             DeviceState.Playing,
             DeviceState.Paused,
             DeviceState.Loading,
@@ -874,7 +874,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             try:
                 if data := await self._atv.metadata.playing():
                     await self._analyze_updated_data(update, data)
-                    self._state = data.device_state
+                    self._device_state = data.device_state
                 else:
                     # No playback data available, clear the artwork
                     await self._process_artwork(update, None)
@@ -906,7 +906,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
 
     async def _process_artwork(self, update: dict[Any, Any], data: pyatv.interface.Playing | None):
         current_media_image_url = self._media_image_url
-        if self._state not in [DeviceState.Idle, DeviceState.Stopped]:
+        if self._device_state not in [DeviceState.Idle, DeviceState.Stopped]:
             try:
                 if data:
                     playback_hash = hash((data.title, data.artist, data.album))
@@ -1252,7 +1252,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         """Set output device selection."""
         if device_name is None:
             return StatusCodes.BAD_REQUEST
-        device_entry = self._output_devices.get(device_name)
+        device_entry = self._output_devices.get(device_name, None)
         if device_entry is None:
             _LOG.warning(
                 "Output device not found in the list %s (list : %s)", device_name, self.output_devices_combinations

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -120,6 +120,7 @@ MEDIA_TYPE_MAPPING = {
 REPEAT_MAPPING = {RepeatState.Off: RepeatMode.OFF, RepeatState.All: RepeatMode.ALL, RepeatState.Track: RepeatMode.ONE}
 
 
+# TODO rename confusing function name: nothing to do with debouncing, this is a deferred function call
 def debounce(wait: float):
     """Debounce function with delay in seconds."""
 
@@ -243,7 +244,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         self._pairing_process: pyatv.interface.PairingHandler | None = None
         self._polling = None
         self._poll_interval: int = 10
-        self._state: DeviceState | PowerState | None = None
+        self._state: DeviceState | None = None
         self._app_list: dict[str, str] = {}
         self._available_output_devices: dict[str, str] = {}
         self._output_devices: OrderedDict[str, list[str]] = OrderedDict[str, list[str]]()
@@ -298,7 +299,8 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         if self._atv is None:
             return None
 
-        # Unfortunately, we can't trust the power API; there are random connect issues: https://github.com/postlund/pyatv/issues/2823
+        # Unfortunately, we can't trust the power API; there are random connect issues:
+        # https://github.com/postlund/pyatv/issues/2823
         if self._atv.power.power_state != PowerState.Unknown:
             return self._atv.power.power_state == PowerState.On
 
@@ -311,13 +313,14 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
 
     @property
     def media_state(self) -> MediaState:
-        """Return the device state."""
+        """Return the media-player state."""
         if self._state is None:
             return MediaState.OFF
-        if isinstance(self._state, PowerState):
-            if self._state == PowerState.Off:
-                return MediaState.OFF
-            return MediaState.ON
+        # FIXME(#117) mixed up state handling: rewrite
+        # if isinstance(self._state, PowerState):
+        #     if self._state == PowerState.Off:
+        #         return MediaState.OFF
+        #     return MediaState.ON
         return MEDIA_STATE_MAPPING.get(self._state, MediaState.UNKNOWN)
 
     @property
@@ -701,7 +704,8 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         await self._process_artwork(update, data)
 
         if data.title is not None:
-            # TODO filter out non-printable characters, for example all emojis
+            # TODO this should be a generic function and not just for the title.
+            #      There's already `_replace_bad_chars` in driver.py which could be made a generic utility function.
             # workaround for Plex DVR
             if data.title.startswith("(null):"):
                 title = data.title.removeprefix("(null):").strip()
@@ -754,9 +758,12 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         power_state = await self._get_power_state()
         # off state is not included in metadata, don't override it
         current_state = self.media_state
-        if power_state and power_state == PowerState.Off:
-            self._state = PowerState.Off
-        else:
+        # FIXME(#117) _state is NOT PowerState: rewrite!
+        # if power_state and power_state == PowerState.Off:
+        #     self._state = PowerState.Off
+        # else:
+        #     self._state = data.device_state
+        if power_state != PowerState.Off:
             self._state = data.device_state
 
         if current_state != self.media_state:
@@ -871,8 +878,9 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             update = {}
             current_state = self.media_state
             power_state = await self._get_power_state()
-            if power_state and power_state == PowerState.Off:
-                self._state = PowerState.Off
+            # FIXME(#117) _state is NOT PowerState: rewrite!
+            # if power_state and power_state == PowerState.Off:
+            #     self._state = PowerState.Off
 
             if self._is_feature_available(FeatureName.App) and self._atv.metadata.app.name:
                 update[MediaAttr.SOURCE] = self._atv.metadata.app.name

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -154,7 +154,8 @@ def async_handle_atvlib_errors(
     Handle errors when calling commands in the AppleTv class.
 
     Decorator for the AppleTv class:
-    - Check if device is connected.
+
+    - Check if device is connected (``self._atv`` is set).
     - Log errors occurred when calling an Apple TV library function.
     - Translate errors into UC status codes to return to the Remote.
 
@@ -339,13 +340,16 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
     def app_name(self) -> str:
         """Return the current app name."""
         app_name = ""
-        if self._atv and self._is_feature_available(FeatureName.App) and self._atv.metadata:
+        if self._atv is None:
+            return app_name
+        try:
             app = self._atv.metadata.app
             if app:
                 app_name = app.name
-                if app_name is None:
-                    app_name = ""
-        return app_name
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Most common exception is pyatv.exceptions.NotSupportedError, but there might be others
+            _LOG.exception("[%s] Error getting app name", self.log_id)
+        return app_name if app_name else ""
 
     @property
     def app_names(self) -> list[str]:


### PR DESCRIPTION
This pull request addresses critical issues with state management and power state reliability for the Apple TV integration. It untangles the confusion between connection states, playback states, and physical power states, while providing robust fallbacks for unreliable API responses.

#### Key Changes and Fixes

##### 1. State Handling Refactoring
*   **Separation of Concerns**: Reverted and rewrote `AppleTv._state` handling. It is now strictly limited to `DeviceState` (playback states) and no longer mixed with `PowerState`.
*   **Media State Logic**: The `media_state` property now correctly prioritizes checking the physical `power_state` (Standby vs On) before evaluating playback states.
*   **Property Cleanup**: Removed the unused and confusing `AppleTv.state` property.

##### 2. Power API Reliability & Fallbacks
*   **Best-Effort Power Management**: Addressed the unreliable `pyatv` power API (per pyatv issue `#2823`). The integration now logs a warning if the power state is unavailable instead of failing.
*   **Assumed State Mechanism**: Introduced an `_assumed_state` in `AppleTVMediaPlayer` to provide a fallback for toggle commands when the device power state is reported as `Unknown`.
*   **Safe Access**: Added a dedicated `power_state` property that safely handles protocol-specific feature availability and connection status.

##### 3. Clarified Connection vs. Device State
*   **Renamed `is_on` to `is_enabled`**: Replaced the confusing `is_on` property with `is_enabled`. This now clearly represents the integration's intent to connect and auto-reconnect, rather than the device's physical power state.
*   **Command Flow**: Updated command handling to ensure the device attempts to connect if it is "enabled" but not currently active.

##### 4. Robust Connection & Error Handling
*   **Unified Disconnect Logic**: Deduplicated code in `driver.py` for handling disconnections and connection errors.
*   **Entity Status Management**: Entities are now consistently set to `UNAVAILABLE` when a device disconnects or encounters a connection error.
*   **Scoped Error Reporting**: Stopped sending a global integration `ERROR` state when an individual device fails, ensuring that one offline Apple TV does not impact the status of other devices.

##### 5. Miscellaneous Improvements
*   **Logging Refinement**: Improved polling task logging and reduced excessive log noise during routine updates.
*   **Metadata Safety**: Implemented safer access to metadata and application names.
*   **Bug Fixes**: Fixed logic in `set_output_device` regarding empty array checks and corrected event parameter passing.

---

- Fixes #93 
- Fixes #117 