### PR TITLE
Improve entity attribute change filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ _Changes in the next release_
 - Update ucapi to 0.6.0 ([#107](https://github.com/unfoldedcircle/integration-appletv/pull/107)).
 - Update pylint version ([#112](https://github.com/unfoldedcircle/integration-appletv/pull/112)).
 - State handling refactor for improved reliability and fallback if power state API is not available ([#120](https://github.com/unfoldedcircle/integration-appletv/pull/120)).
-- Refactored entity attribute update and change filter 
+- Refactored entity attribute update and change filter ([#122](https://github.com/unfoldedcircle/integration-appletv/pull/122)).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _Changes in the next release_
 - Regression with tvOS 26.5 by @albaintor ([#110](https://github.com/unfoldedcircle/integration-appletv/pull/110)).
 - Create a valid driver.json file in the custom driver archive with custom driver_id and name ([#116](https://github.com/unfoldedcircle/integration-appletv/pull/116)).
 - Entity state is not updated if Apple TV device disconnects ([#93](https://github.com/unfoldedcircle/integration-appletv/issues/93)).
+- Always return the command result to the caller ([#121](https://github.com/unfoldedcircle/integration-appletv/pull/121)).
 
 ### Added
 - Add remote-entity by @albaintor ([#61](https://github.com/unfoldedcircle/integration-appletv/pull/61), [#115](https://github.com/unfoldedcircle/integration-appletv/pull/115)).
@@ -22,6 +23,7 @@ _Changes in the next release_
 - Update ucapi to 0.6.0 ([#107](https://github.com/unfoldedcircle/integration-appletv/pull/107)).
 - Update pylint version ([#112](https://github.com/unfoldedcircle/integration-appletv/pull/112)).
 - State handling refactor for improved reliability and fallback if power state API is not available ([#120](https://github.com/unfoldedcircle/integration-appletv/pull/120)).
+- Refactored entity attribute update and change filter 
 
 ---
 

--- a/intg-appletv/config.py
+++ b/intg-appletv/config.py
@@ -10,14 +10,16 @@ import dataclasses
 import json
 import logging
 import os
+from abc import ABC, abstractmethod
 from asyncio import Lock
 from dataclasses import dataclass
 from enum import Enum
-from typing import Iterator
+from typing import Any, Iterator, Type
 
 import discover
 import pyatv
-from ucapi import Entity, EntityTypes
+from ucapi import EntityTypes, IntegrationAPI
+from utils import filter_attributes, truncate_dict
 
 _LOG = logging.getLogger(__name__)
 
@@ -31,13 +33,57 @@ class AtvProtocol(str, Enum):
     COMPANION = "companion"
 
 
-class AppleTVEntity(Entity):
-    """Global AppleTV entity."""
+class AppleTVEntity(ABC):
+    """Abstract AppleTV entity."""
+
+    def __init__(self, api: IntegrationAPI):
+        """Initialize the AppleTVEntity."""
+        self._api: IntegrationAPI = api
 
     @property
-    def deviceid(self) -> str:
-        """Return the device identifier."""
-        raise NotImplementedError()
+    @abstractmethod
+    def atv_id(self) -> str:
+        """Return the ATV device identifier."""
+
+    @property
+    @abstractmethod
+    def attribute_enum(self) -> Type[Enum]:
+        """Return the attribute enum of the concrete entity."""
+
+    def update_attributes(self, update: dict[str, Any], *, force: bool = False) -> None:
+        """
+        Update the configured entity attributes from the given ATV update.
+
+        If the entity is not configured, the updated attributes are ignored.
+
+        **Attention:** the update dictionary can be modified in place!
+
+        :param update: dictionary containing the updated properties.
+        :param force: if True, update attributes even if they haven't changed.
+        """
+        if force:
+            # FIXME(#118) does not yet work for sensor and selector entities!
+            attributes = filter_attributes(update, self.attribute_enum)
+        else:
+            attributes = self.filter_changed_attributes(update)
+
+        if attributes:
+            if _LOG.isEnabledFor(logging.DEBUG):
+                # pylint: disable=E1101
+                _LOG.debug("Updating attributes for entity %s : %s", self.id, truncate_dict(attributes))
+            # pylint: disable=E1101
+            self._api.configured_entities.update_attributes(self.id, attributes)
+
+    @abstractmethod
+    def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
+        """
+        Filter the given attributes from an ATV update and return only the changed values.
+
+        **Attention:** the update dictionary can be modified in place!
+
+        :param update: dictionary containing the updated properties.
+        :return: dictionary containing only the changed attributes.
+        """
 
 
 @dataclass

--- a/intg-appletv/config.py
+++ b/intg-appletv/config.py
@@ -10,16 +10,14 @@ import dataclasses
 import json
 import logging
 import os
-from abc import ABC, abstractmethod
 from asyncio import Lock
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Iterator, Type
+from typing import Iterator
 
 import discover
 import pyatv
-from ucapi import EntityTypes, IntegrationAPI
-from utils import filter_attributes, truncate_dict
+from ucapi import EntityTypes
 
 _LOG = logging.getLogger(__name__)
 
@@ -31,59 +29,6 @@ class AtvProtocol(str, Enum):
 
     AIRPLAY = "airplay"
     COMPANION = "companion"
-
-
-class AppleTVEntity(ABC):
-    """Abstract AppleTV entity."""
-
-    def __init__(self, api: IntegrationAPI):
-        """Initialize the AppleTVEntity."""
-        self._api: IntegrationAPI = api
-
-    @property
-    @abstractmethod
-    def atv_id(self) -> str:
-        """Return the ATV device identifier."""
-
-    @property
-    @abstractmethod
-    def attribute_enum(self) -> Type[Enum]:
-        """Return the attribute enum of the concrete entity."""
-
-    def update_attributes(self, update: dict[str, Any], *, force: bool = False) -> None:
-        """
-        Update the configured entity attributes from the given ATV update.
-
-        If the entity is not configured, the updated attributes are ignored.
-
-        **Attention:** the update dictionary can be modified in place!
-
-        :param update: dictionary containing the updated properties.
-        :param force: if True, update attributes even if they haven't changed.
-        """
-        if force:
-            # FIXME(#118) does not yet work for sensor and selector entities!
-            attributes = filter_attributes(update, self.attribute_enum)
-        else:
-            attributes = self.filter_changed_attributes(update)
-
-        if attributes:
-            if _LOG.isEnabledFor(logging.DEBUG):
-                # pylint: disable=E1101
-                _LOG.debug("Updating attributes for entity %s : %s", self.id, truncate_dict(attributes))
-            # pylint: disable=E1101
-            self._api.configured_entities.update_attributes(self.id, attributes)
-
-    @abstractmethod
-    def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
-        """
-        Filter the given attributes from an ATV update and return only the changed values.
-
-        **Attention:** the update dictionary can be modified in place!
-
-        :param update: dictionary containing the updated properties.
-        :return: dictionary containing only the changed attributes.
-        """
 
 
 @dataclass

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -26,7 +26,6 @@ from i18n import _a
 from media_player import AppleTVMediaPlayer
 from remote import AppleTVRemote
 from ucapi import Entity, media_player
-from utils import filter_attributes, truncate_dict
 
 _LOG = logging.getLogger("driver")  # avoid having __main__ in log messages
 if sys.platform == "win32":
@@ -92,28 +91,17 @@ async def on_subscribe_entities(entity_ids: list[str]) -> None:
     _LOG.debug("Subscribe entities event: %s", entity_ids)
 
     for entity_id in entity_ids:
-        entity: AppleTVEntity | None = api.configured_entities.get(entity_id)
-        if entity is None:
-            _LOG.warning("Subscribed entity %s not found", entity_id)
+        configured_entity: Entity | None = api.configured_entities.get(entity_id)
+        if configured_entity is None or not isinstance(configured_entity, AppleTVEntity):
             continue
-        device_id = entity.deviceid
+        device_id = configured_entity.atv_id
         if device_id in _configured_atvs:
             device = _configured_atvs[device_id]
-            if isinstance(entity, AppleTVRemote):
-                api.configured_entities.update_attributes(
-                    entity_id, entity.filter_changed_attributes(device.attributes)
-                )
-            elif isinstance(entity, media_player.MediaPlayer):
-                api.configured_entities.update_attributes(
-                    entity_id, filter_attributes(device.attributes, ucapi.media_player.Attributes)
-                )
-            elif isinstance(entity, selector.AppleTVSelect):
-                api.configured_entities.update_attributes(entity_id, entity.update_attributes())
-            elif isinstance(entity, sensor.AppleTVSensor):
-                api.configured_entities.update_attributes(entity_id, entity.update_attributes())
+            # trigger a full attributes update
+            configured_entity.update_attributes(device.attributes, force=True)
             continue
 
-        device = config.devices.get(device_id)
+        device = config.devices.get(device_id) if config.devices else None
         if device:
             _add_configured_atv(device)
         else:
@@ -125,8 +113,12 @@ async def on_unsubscribe_entities(entity_ids: list[str]) -> None:
     """On unsubscribe, we disconnect the objects and remove listeners for events."""
     _LOG.debug("Unsubscribe entities event: %s", entity_ids)
     for entity_id in entity_ids:
-        entity: AppleTVEntity | None = api.configured_entities.get(entity_id)
-        device_id = entity.deviceid if entity else config.base_entity_id_from_entity_id(entity_id)
+        entity: Entity | None = api.configured_entities.get(entity_id)
+        device_id = (
+            entity.atv_id
+            if entity and isinstance(entity, AppleTVEntity)
+            else config.base_entity_id_from_entity_id(entity_id)
+        )
         # only unsubscribe the device once all its entities are gone
         if device_id in _configured_atvs and not _get_entities(device_id):
             device = _configured_atvs.pop(device_id)
@@ -170,31 +162,30 @@ def _set_all_entities_to_unavailable(identifier: str) -> None:
         )
 
 
-def _get_entities(device_id: str, include_all=False) -> list[Entity]:
+def _get_entities(device_id: str, include_all=False) -> list[AppleTVEntity]:
     """
     Return all associated entities of the given device.
 
-    :param device_id: the device  identifier
-    :param include_all: include both configured and available entities
-    :return: list of entities
+    :param device_id: the device identifier
+    :param include_all: includes both configured and available entities
+    :return: list of ``AppleTVEntity``
     """
-    entities = []
+    entities: list[AppleTVEntity] = []
     for entity_entry in api.configured_entities.get_all():
-        entity: AppleTVEntity | None = api.configured_entities.get(entity_entry.get("entity_id", ""))
-        if entity is None or entity.deviceid != device_id:
+        entity: Entity | None = api.configured_entities.get(entity_entry.get("entity_id", ""))
+        if entity is None or not isinstance(entity, AppleTVEntity) or entity.atv_id != device_id:
             continue
         entities.append(entity)
     if not include_all:
         return entities
     for entity_entry in api.available_entities.get_all():
-        entity: AppleTVEntity | None = api.available_entities.get(entity_entry.get("entity_id", ""))
-        if entity is None or entity.deviceid != device_id:
+        entity: Entity | None = api.available_entities.get(entity_entry.get("entity_id", ""))
+        if entity is None or not isinstance(entity, AppleTVEntity) or entity.atv_id != device_id:
             continue
         entities.append(entity)
     return entities
 
 
-# pylint: disable=too-many-branches,too-many-statements
 async def on_atv_update(device_id: str, update: dict[str, Any] | None) -> None:
     """
     Update attributes of all configured entities if ATV properties changed.
@@ -210,21 +201,7 @@ async def on_atv_update(device_id: str, update: dict[str, Any] | None) -> None:
         update = device.attributes
 
     for configured_entity in _get_entities(device_id):
-        attributes = {}
-        if isinstance(configured_entity, media_player.MediaPlayer):
-            attributes = filter_attributes(update, ucapi.media_player.Attributes)
-        elif isinstance(configured_entity, selector.AppleTVSelect):
-            attributes = configured_entity.update_attributes(update)
-        elif isinstance(configured_entity, sensor.AppleTVSensor):
-            attributes = configured_entity.update_attributes(update)
-        elif isinstance(configured_entity, AppleTVRemote):
-            attributes = configured_entity.filter_changed_attributes(update)
-
-        # TODO(#118) filter out unchanged properties to limit entity_change events. See Denon AVR implementation.
-        #            Otherwise there will be events every 10s triggered from the poller.
-        if attributes:
-            _LOG.debug("Updating attributes for entity %s : %s", configured_entity.id, truncate_dict(attributes))
-            api.configured_entities.update_attributes(configured_entity.id, attributes)
+        configured_entity.update_attributes(update)
 
 
 def _replace_bad_chars(value: str) -> str:
@@ -271,14 +248,14 @@ def _register_available_entities(device_config: config.AtvDevice, device: tv.App
     :param device: ATV device instance
     :return: True if at least one device entity was added, False if all entities were already in storage.
     """
-    media_player_entity = AppleTVMediaPlayer(device_config, device)
-    entities: list[AppleTVEntity] = [
+    media_player_entity = AppleTVMediaPlayer(device_config, device, api)
+    entities: list[Entity] = [
         media_player_entity,
-        AppleTVRemote(device_config, device, mp_entity=media_player_entity),
-        selector.AppSelect(device_config, device),
-        sensor.AppSensor(device_config, device),
-        selector.AudioOutputSelect(device_config, device),
-        sensor.AudioOutputSensor(device_config, device),
+        AppleTVRemote(device_config, device, api, mp_entity=media_player_entity),
+        selector.AppSelect(device_config, device, api),
+        sensor.AppSensor(device_config, device, api),
+        selector.AudioOutputSelect(device_config, device, api),
+        sensor.AudioOutputSensor(device_config, device, api),
     ]
 
     added = False

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -99,9 +99,10 @@ async def on_subscribe_entities(entity_ids: list[str]) -> None:
         device_id = configured_entity.atv_id
         if device_id in _configured_atvs:
             device = _configured_atvs[device_id]
-            state = device.media_state
-            # It doesn't matter if we use the media_player.Attributes enum. It's called the same for all entities
-            configured_entity.update_attributes({media_player.Attributes.STATE: state}, force=True)
+            # Set all current attributes in the configured entity to make sure it is up to date once the Remote sends a
+            # `get_entity_states` request. Note: `update_attributes` will also trigger an entity_change event.
+            # Better to have too many `entity_change` events than old data!
+            configured_entity.update_attributes(device.attributes, force=True)
             continue
 
         device = config.devices.get(device_id) if config.devices else None

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -156,9 +156,9 @@ def on_atv_connection_error(device_id: str, message) -> None:
 
 def _mark_entities_unavailable(device_id: str, *, force: bool) -> None:
     """Set all entities of a device to state UNAVAILABLE."""
-    for configured_entity in _get_entities(device_id):
+    for entity in _get_entities(device_id, include_all=True):
         # The STATE attribute is common for all entities, just use the media player state :-)
-        configured_entity.update_attributes(
+        entity.update_attributes(
             {ucapi.media_player.Attributes.STATE: ucapi.media_player.States.UNAVAILABLE.value}, force=force
         )
 
@@ -201,8 +201,8 @@ def on_atv_update(device_id: str, update: dict[str, Any]) -> None:
         device = _configured_atvs[device_id]
         update = device.attributes
 
-    for configured_entity in _get_entities(device_id):
-        configured_entity.update_attributes(update)
+    for entity in _get_entities(device_id, include_all=True):
+        entity.update_attributes(update)
 
 
 def _replace_bad_chars(value: str) -> str:

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -92,8 +92,10 @@ async def on_subscribe_entities(entity_ids: list[str]) -> None:
     # force an entity change event with the current state for all subscribed entities
     for entity_id in entity_ids:
         configured_entity: Entity | None = api.configured_entities.get(entity_id)
-        if configured_entity is None or not isinstance(configured_entity, AppleTVEntity):
+        if configured_entity is None:
             continue
+        assert isinstance(configured_entity, AppleTVEntity)
+
         device_id = configured_entity.atv_id
         if device_id in _configured_atvs:
             device = _configured_atvs[device_id]
@@ -174,14 +176,20 @@ def _get_entities(device_id: str, include_all=False) -> list[AppleTVEntity]:
     entities: list[AppleTVEntity] = []
     for entity_entry in api.configured_entities.get_all():
         entity: Entity | None = api.configured_entities.get(entity_entry.get("entity_id", ""))
-        if entity is None or not isinstance(entity, AppleTVEntity) or entity.atv_id != device_id:
+        if entity is None:
+            continue
+        assert isinstance(entity, AppleTVEntity)
+        if entity.atv_id != device_id:
             continue
         entities.append(entity)
     if not include_all:
         return entities
     for entity_entry in api.available_entities.get_all():
         entity: Entity | None = api.available_entities.get(entity_entry.get("entity_id", ""))
-        if entity is None or not isinstance(entity, AppleTVEntity) or entity.atv_id != device_id:
+        if entity is None:
+            continue
+        assert isinstance(entity, AppleTVEntity)
+        if entity.atv_id != device_id:
             continue
         entities.append(entity)
     return entities

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -21,7 +21,7 @@ import setup_flow
 import tv
 import ucapi
 import ucapi.api as uc
-from config import AppleTVEntity
+from entities import AppleTVEntity
 from i18n import _a
 from media_player import AppleTVMediaPlayer
 from remote import AppleTVRemote
@@ -89,7 +89,7 @@ async def on_subscribe_entities(entity_ids: list[str]) -> None:
     :param entity_ids: entity identifiers.
     """
     _LOG.debug("Subscribe entities event: %s", entity_ids)
-
+    # force an entity change event with the current state for all subscribed entities
     for entity_id in entity_ids:
         configured_entity: Entity | None = api.configured_entities.get(entity_id)
         if configured_entity is None or not isinstance(configured_entity, AppleTVEntity):
@@ -97,8 +97,9 @@ async def on_subscribe_entities(entity_ids: list[str]) -> None:
         device_id = configured_entity.atv_id
         if device_id in _configured_atvs:
             device = _configured_atvs[device_id]
-            # trigger a full attributes update
-            configured_entity.update_attributes(device.attributes, force=True)
+            state = device.media_state
+            # It doesn't matter if we use the media_player.Attributes enum. It's called the same for all entities
+            configured_entity.update_attributes({media_player.Attributes.STATE: state}, force=True)
             continue
 
         device = config.devices.get(device_id) if config.devices else None
@@ -127,38 +128,38 @@ async def on_unsubscribe_entities(entity_ids: list[str]) -> None:
             device.events.remove_all_listeners()
 
 
-async def on_atv_connected(identifier: str) -> None:
+async def on_atv_connected(device_id: str) -> None:
     """Handle ATV connection."""
-    _LOG.debug("Apple TV connected: %s", identifier)
+    _LOG.debug("Apple TV connected: %s", device_id)
     await api.set_device_state(ucapi.DeviceStates.CONNECTED)  # just to make sure the device state is set
 
-    if identifier in _configured_atvs:
-        atv = _configured_atvs[identifier]
+    if device_id in _configured_atvs:
+        atv = _configured_atvs[device_id]
         state = atv.media_state
         # make sure to not send an outdated state, not sure if media_state is immediately available
         if state == tv.MediaState.UNAVAILABLE:
             state = media_player.States.UNKNOWN
-        await on_atv_update(identifier, {media_player.Attributes.STATE: state})
+        on_atv_update(device_id, {media_player.Attributes.STATE: state})
 
 
-def on_atv_disconnected(identifier: str) -> None:
+def on_atv_disconnected(device_id: str) -> None:
     """Handle ATV disconnection. Set all entities to the UNAVAILABLE state."""
-    _LOG.debug("[%s] Apple TV disconnected", identifier)
-    _set_all_entities_to_unavailable(identifier)
+    _LOG.debug("[%s] Apple TV disconnected", device_id)
+    _mark_entities_unavailable(device_id, force=True)
 
 
-def on_atv_connection_error(identifier: str, message) -> None:
+def on_atv_connection_error(device_id: str, message) -> None:
     """Set entities of ATV to state UNAVAILABLE if ATV connection error occurred."""
-    _LOG.error("[%s] Apple TV connection error: %s", identifier, message)
-    _set_all_entities_to_unavailable(identifier)
+    _LOG.error("[%s] Apple TV connection error: %s", device_id, message)
+    _mark_entities_unavailable(device_id, force=False)
 
 
-def _set_all_entities_to_unavailable(identifier: str) -> None:
+def _mark_entities_unavailable(device_id: str, *, force: bool) -> None:
     """Set all entities of a device to state UNAVAILABLE."""
-    for configured_entity in _get_entities(identifier):
+    for configured_entity in _get_entities(device_id):
         # The STATE attribute is common for all entities, just use the media player state :-)
-        api.configured_entities.update_attributes(
-            configured_entity.id, {ucapi.media_player.Attributes.STATE: ucapi.media_player.States.UNAVAILABLE.value}
+        configured_entity.update_attributes(
+            {ucapi.media_player.Attributes.STATE: ucapi.media_player.States.UNAVAILABLE.value}, force=force
         )
 
 
@@ -186,7 +187,7 @@ def _get_entities(device_id: str, include_all=False) -> list[AppleTVEntity]:
     return entities
 
 
-async def on_atv_update(device_id: str, update: dict[str, Any] | None) -> None:
+def on_atv_update(device_id: str, update: dict[str, Any]) -> None:
     """
     Update attributes of all configured entities if ATV properties changed.
 

--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -197,18 +197,11 @@ def _get_entities(device_id: str, include_all=False) -> list[AppleTVEntity]:
 
 def on_atv_update(device_id: str, update: dict[str, Any]) -> None:
     """
-    Update attributes of all configured entities if ATV properties changed.
+    Update attributes of all entities if ATV properties changed.
 
     :param device_id: ATV media-player entity identifier
     :param update: dictionary containing the updated properties.
-                  ``None`` indicates that the last known entity attributes should be sent to the Remote.
     """
-    if update is None:
-        if device_id not in _configured_atvs:
-            return
-        device = _configured_atvs[device_id]
-        update = device.attributes
-
     for entity in _get_entities(device_id, include_all=True):
         entity.update_attributes(update)
 

--- a/intg-appletv/entities.py
+++ b/intg-appletv/entities.py
@@ -1,0 +1,73 @@
+"""
+Common entity interface for Apple TV integration.
+
+:copyright: (c) 2026 by Unfolded Circle ApS.
+:license: Mozilla Public License Version 2.0, see LICENSE for more details.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any, Type
+
+from ucapi import IntegrationAPI
+from utils import filter_attributes, truncate_dict
+
+_LOG = logging.getLogger(__name__)
+
+
+class AppleTVEntity(ABC):
+    """Abstract AppleTV entity."""
+
+    def __init__(self, api: IntegrationAPI):
+        """Initialize the AppleTVEntity."""
+        self._api: IntegrationAPI = api
+
+    @property
+    @abstractmethod
+    def atv_id(self) -> str:
+        """Return the ATV device identifier."""
+
+    @property
+    @abstractmethod
+    def attribute_enum(self) -> Type[Enum]:
+        """Return the attribute enum of the concrete entity."""
+
+    def update_attributes(self, update: dict[str, Any], *, force: bool = False) -> None:
+        """
+        Update the configured entity attributes from the given ATV update.
+
+        - If the entity is not configured, the updated attributes are ignored.
+        - Only changed attributes are updated (and will trigger an ``entity_changed`` event), unless the ``force``
+          parameter is True.
+
+        **Attention:**
+         - The update dictionary can be modified in place!
+         - The ``force`` parameter will apply all ``update`` keys belonging to the entity's attribute
+           without further filtering.
+
+        :param update: dictionary containing the updated properties.
+        :param force: if True, update attributes even if they haven't changed.
+        """
+        if force:
+            attributes = filter_attributes(update, self.attribute_enum)
+        else:
+            attributes = self.filter_changed_attributes(update)
+
+        if attributes:
+            if _LOG.isEnabledFor(logging.DEBUG):
+                # pylint: disable=E1101
+                _LOG.debug("Updating attributes for entity %s : %s", self.id, truncate_dict(attributes))
+            # pylint: disable=E1101
+            self._api.configured_entities.update_attributes(self.id, attributes)
+
+    @abstractmethod
+    def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
+        """
+        Filter the given attributes from an ATV update and return only the changed values.
+
+        **Attention:** the update dictionary can be modified in place!
+
+        :param update: dictionary containing the updated properties.
+        :return: dictionary containing only the changed attributes.
+        """

--- a/intg-appletv/entities.py
+++ b/intg-appletv/entities.py
@@ -12,7 +12,7 @@ from enum import Enum, StrEnum
 from typing import Any, Type
 
 from ucapi import IntegrationAPI, media_player
-from utils import filter_attributes, truncate_dict
+from utils import truncate_dict
 
 _LOG = logging.getLogger(__name__)
 
@@ -43,54 +43,43 @@ class AppleTVEntity(ABC):
     def atv_id(self) -> str:
         """Return the ATV device identifier."""
 
-    @property
-    @abstractmethod
-    def attribute_enum(self) -> Type[Enum]:
-        """Return the attribute enum of the concrete entity."""
-
     @abstractmethod
     def state_from_media_player_state(self, state: media_player.States) -> Type[Enum]:
         """Map media-player state to target entity state."""
 
     def update_attributes(self, update: dict[str, Any], *, force: bool = False) -> None:
         """
-        Update the configured entity attributes from the given ATV update.
+        Update the entity attributes from the given ATV update.
 
-        - If the entity is not configured, the updated attributes are ignored.
+        - Updates configured and available entities.
         - Only changed attributes are updated (and will trigger an ``entity_changed`` event), unless the ``force``
           parameter is True.
 
-        **Attention:**
-         - The update dictionary can be modified in place!
-         - The ``force`` parameter will apply all ``update`` keys belonging to the entity's attribute
-           without further filtering.
+        **Attention:** The update dictionary can be modified in place!
 
-        :param update: dictionary containing the updated properties.
-        :param force: if True, update attributes even if they haven't changed.
+        :param update: Dictionary containing the updated properties.
+        :param force: If True, update attributes even if they haven't changed.
         """
-        if force:
-            if media_player.Attributes.STATE in update:
-                state = self.state_from_media_player_state(update[media_player.Attributes.STATE])
-                update[media_player.Attributes.STATE] = state
-            attributes = filter_attributes(update, self.attribute_enum)
-
-        else:
-            attributes = self.filter_changed_attributes(update)
+        attributes = self.filter_attributes(update, force=force)
 
         if attributes:
-            if _LOG.isEnabledFor(logging.DEBUG):
-                # pylint: disable=E1101
-                _LOG.debug("Updating attributes for entity %s : %s", self.id, json.dumps(truncate_dict(attributes)))
             # pylint: disable=E1101
-            self._api.configured_entities.update_attributes(self.id, attributes)
+            entity_id = self.id
+            if _LOG.isEnabledFor(logging.DEBUG):
+                _LOG.debug("Updating attributes for entity %s : %s", entity_id, json.dumps(truncate_dict(attributes)))
+            if self._api.configured_entities.contains(entity_id):
+                self._api.configured_entities.update_attributes(entity_id, attributes)
+            else:
+                self._api.available_entities.update_attributes(entity_id, attributes)
 
     @abstractmethod
-    def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
+    def filter_attributes(self, update: dict[str, Any], *, force: bool = False) -> dict[str, Any]:
         """
-        Filter the given attributes from an ATV update and return only the changed values.
+        Filter the given attributes from an ATV update and return only the related entity values.
 
         **Attention:** the update dictionary can be modified in place!
 
         :param update: dictionary containing the updated properties.
+        :param force: If True, update attributes even if they haven't changed since the last update.
         :return: dictionary containing only the changed attributes.
         """

--- a/intg-appletv/entities.py
+++ b/intg-appletv/entities.py
@@ -8,13 +8,27 @@ Common entity interface for Apple TV integration.
 import json
 import logging
 from abc import ABC, abstractmethod
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Any, Type
 
 from ucapi import IntegrationAPI, media_player
 from utils import filter_attributes, truncate_dict
 
 _LOG = logging.getLogger(__name__)
+
+
+class AppleTVSelects(StrEnum):
+    """Apple TV select values."""
+
+    SELECT_APP = "select_app"
+    SELECT_AUDIO_OUTPUT = "select_audio_output"
+
+
+class AppleTVSensors(StrEnum):
+    """Apple TV sensor values."""
+
+    SENSOR_APP = "sensor_app"
+    SENSOR_AUDIO_OUTPUT = "sensor_audio_output"
 
 
 class AppleTVEntity(ABC):

--- a/intg-appletv/entities.py
+++ b/intg-appletv/entities.py
@@ -55,8 +55,6 @@ class AppleTVEntity(ABC):
         - Only changed attributes are updated (and will trigger an ``entity_changed`` event), unless the ``force``
           parameter is True.
 
-        **Attention:** The update dictionary can be modified in place!
-
         :param update: Dictionary containing the updated properties.
         :param force: If True, update attributes even if they haven't changed.
         """
@@ -76,8 +74,6 @@ class AppleTVEntity(ABC):
     def filter_attributes(self, update: dict[str, Any], *, force: bool = False) -> dict[str, Any]:
         """
         Filter the given attributes from an ATV update and return only the related entity values.
-
-        **Attention:** the update dictionary can be modified in place!
 
         :param update: dictionary containing the updated properties.
         :param force: If True, update attributes even if they haven't changed since the last update.

--- a/intg-appletv/entities.py
+++ b/intg-appletv/entities.py
@@ -32,10 +32,16 @@ class AppleTVSensors(StrEnum):
 
 
 class AppleTVEntity(ABC):
-    """Abstract AppleTV entity."""
+    """Mixin for Apple TV backed ucapi entities.
 
-    def __init__(self, api: IntegrationAPI):
+    The concrete class must also inherit from a ucapi Entity subclass such as
+    MediaPlayer, Remote, Select, or Sensor.
+    """
+
+    def __init__(self, entity_id: str, api: IntegrationAPI):
         """Initialize the AppleTVEntity."""
+        # pragmatic and explicit way to access the Entity.id property instead of the hackish `self.id`
+        self._entity_id = entity_id
         self._api: IntegrationAPI = api
 
     @property
@@ -61,14 +67,14 @@ class AppleTVEntity(ABC):
         attributes = self.filter_attributes(update, force=force)
 
         if attributes:
-            # pylint: disable=E1101
-            entity_id = self.id
             if _LOG.isEnabledFor(logging.DEBUG):
-                _LOG.debug("Updating attributes for entity %s : %s", entity_id, json.dumps(truncate_dict(attributes)))
-            if self._api.configured_entities.contains(entity_id):
-                self._api.configured_entities.update_attributes(entity_id, attributes)
+                _LOG.debug(
+                    "Updating attributes for entity %s : %s", self._entity_id, json.dumps(truncate_dict(attributes))
+                )
+            if self._api.configured_entities.contains(self._entity_id):
+                self._api.configured_entities.update_attributes(self._entity_id, attributes)
             else:
-                self._api.available_entities.update_attributes(entity_id, attributes)
+                self._api.available_entities.update_attributes(self._entity_id, attributes)
 
     @abstractmethod
     def filter_attributes(self, update: dict[str, Any], *, force: bool = False) -> dict[str, Any]:

--- a/intg-appletv/entities.py
+++ b/intg-appletv/entities.py
@@ -5,12 +5,13 @@ Common entity interface for Apple TV integration.
 :license: Mozilla Public License Version 2.0, see LICENSE for more details.
 """
 
+import json
 import logging
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Type
 
-from ucapi import IntegrationAPI
+from ucapi import IntegrationAPI, media_player
 from utils import filter_attributes, truncate_dict
 
 _LOG = logging.getLogger(__name__)
@@ -33,6 +34,10 @@ class AppleTVEntity(ABC):
     def attribute_enum(self) -> Type[Enum]:
         """Return the attribute enum of the concrete entity."""
 
+    @abstractmethod
+    def state_from_media_player_state(self, state: media_player.States) -> Type[Enum]:
+        """Map media-player state to target entity state."""
+
     def update_attributes(self, update: dict[str, Any], *, force: bool = False) -> None:
         """
         Update the configured entity attributes from the given ATV update.
@@ -50,14 +55,18 @@ class AppleTVEntity(ABC):
         :param force: if True, update attributes even if they haven't changed.
         """
         if force:
+            if media_player.Attributes.STATE in update:
+                state = self.state_from_media_player_state(update[media_player.Attributes.STATE])
+                update[media_player.Attributes.STATE] = state
             attributes = filter_attributes(update, self.attribute_enum)
+
         else:
             attributes = self.filter_changed_attributes(update)
 
         if attributes:
             if _LOG.isEnabledFor(logging.DEBUG):
                 # pylint: disable=E1101
-                _LOG.debug("Updating attributes for entity %s : %s", self.id, truncate_dict(attributes))
+                _LOG.debug("Updating attributes for entity %s : %s", self.id, json.dumps(truncate_dict(attributes)))
             # pylint: disable=E1101
             self._api.configured_entities.update_attributes(self.id, attributes)
 

--- a/intg-appletv/media_player.py
+++ b/intg-appletv/media_player.py
@@ -7,8 +7,8 @@ Media-player entity functions.
 
 import asyncio
 import logging
-from enum import Enum, StrEnum
-from typing import Any, Type
+from enum import StrEnum
+from typing import Any
 
 from config import AtvDevice
 from entities import AppleTVEntity
@@ -154,11 +154,6 @@ class AppleTVMediaPlayer(MediaPlayer, AppleTVEntity):
     def atv_id(self) -> str:
         """Return the device identifier."""
         return self._device.identifier
-
-    @property
-    def attribute_enum(self) -> Type[Enum]:
-        """Return the media-player attribute enum."""
-        return Attributes
 
     def state_from_media_player_state(self, state: States) -> States:
         """Map media-player state. Pass through state."""
@@ -338,13 +333,28 @@ class AppleTVMediaPlayer(MediaPlayer, AppleTVEntity):
 
         return res if res is not None else StatusCodes.SERVER_ERROR
 
-    def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
-        """Return only the changed attributes."""
+    def filter_attributes(self, update: dict[str, Any], *, force: bool = False) -> dict[str, Any]:
+        """
+        Filter the given attributes from an ATV update and return only the related media-player entity values.
+
+        **Attention:**
+
+        - for ``States.OFF``: all media attributes are reset.
+        - the update dictionary can be modified in place!
+
+        :param update: Dictionary containing the updated properties.
+        :param force: If True, update attributes even if they haven't changed since the last update.
+        :return: Dictionary containing only the changed attributes.
+        """
         attributes: dict[str, Any] = {}
 
+        # pylint: disable=R0801
         for attr in _AVAILABLE_ATTRIBUTES:
             if attr in update:
-                key_update_helper(attr, update[attr], attributes, self.attributes)
+                if force:
+                    attributes[attr] = update[attr]
+                else:
+                    key_update_helper(attr, update[attr], attributes, self.attributes)
 
         if Attributes.STATE in attributes and attributes[Attributes.STATE] == States.OFF:
             AppleTVMediaPlayer.reset_media_data(attributes)

--- a/intg-appletv/media_player.py
+++ b/intg-appletv/media_player.py
@@ -7,23 +7,24 @@ Media-player entity functions.
 
 import asyncio
 import logging
-from enum import StrEnum
-from typing import Any
+from enum import Enum, StrEnum
+from typing import Any, Type
 
-import tv
 from config import AppleTVEntity, AtvDevice
 from hid import UsagePage
 from hid.consumer_control_code import ConsumerControlCode
 from pyatv.const import PowerState
-from ucapi import MediaPlayer, StatusCodes, media_player
+from tv import AppleTv
+from ucapi import IntegrationAPI, MediaPlayer, RepeatMode, StatusCodes
 from ucapi.media_player import (
     Attributes,
     Commands,
     DeviceClasses,
     Features,
     Options,
+    States,
 )
-from utils import filter_attributes
+from utils import filter_attributes, key_update_helper
 
 _LOG = logging.getLogger(__name__)
 # Experimental features, don't seem to work / supported (yet) with ATV4
@@ -70,14 +71,19 @@ def _get_cmd_param(name: str, params: dict[str, Any] | None) -> str | bool | Non
     return params.get(name)
 
 
-class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
+class AppleTVMediaPlayer(MediaPlayer, AppleTVEntity):
     """Representation of a AppleTV Media Player entity."""
 
-    def __init__(self, config_device: AtvDevice, device: tv.AppleTv):
+    def __init__(
+        self,
+        config_device: AtvDevice,
+        device: AppleTv,
+        api: IntegrationAPI,
+    ):
         """Initialize the class."""
         # pylint: disable = R0801
         self._device = device
-        self._assumed_state: media_player.States = media_player.States.OFF
+        self._assumed_state: States = States.OFF
         """Fallback state if device power state is not available."""
         # entity_id = create_entity_id(config_device.name, EntityTypes.MEDIA_PLAYER)
         entity_id = config_device.identifier
@@ -120,11 +126,17 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
         super().__init__(
             entity_id, config_device.name, features, attributes, device_class=DeviceClasses.TV, options=options
         )
+        AppleTVEntity.__init__(self, api)
 
     @property
-    def deviceid(self) -> str:
+    def atv_id(self) -> str:
         """Return the device identifier."""
         return self._device.identifier
+
+    @property
+    def attribute_enum(self) -> Type[Enum]:
+        """Return the media-player attribute enum."""
+        return Attributes
 
     async def _playpause_in_screensaver(self) -> StatusCodes | None:
         """
@@ -140,10 +152,10 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
         # Screensaver state is no longer accessible
         # pylint: disable=W0718
         try:
-            if self._device.media_state != media_player.States.PLAYING and await self._device.screensaver_active():
+            if self._device.media_state != States.PLAYING and await self._device.screensaver_active():
                 _LOG.debug("Screensaver is running, sending menu command for play_pause to exit")
                 await self._device.menu()
-                if self._device.media_state == media_player.States.PAUSED:
+                if self._device.media_state == States.PAUSED:
                     # another awkwardness: the play_pause button doesn't work anymore after exiting the screensaver.
                     # One has to send a dpad select first to start playback. Afterward, play_pause works again...
                     await asyncio.sleep(1)  # delay required, otherwise the second button press is ignored
@@ -179,7 +191,7 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
 
         # Automatically wake ATV from standby if a command is received
         state = self._device.media_state
-        if state == media_player.States.OFF and cmd_id not in (Commands.OFF, Commands.TOGGLE):
+        if state == States.OFF and cmd_id not in (Commands.OFF, Commands.TOGGLE):
             _LOG.debug("Device is off, sending turn on command")
             res = await self._device.turn_on()
             if res != StatusCodes.OK:
@@ -221,13 +233,9 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
                         "Power state is not available for toggle, using assumed state: %s", self._assumed_state
                     )
                     state = self._assumed_state
-                    self._assumed_state = (
-                        media_player.States.OFF
-                        if self._assumed_state == media_player.States.ON
-                        else media_player.States.ON
-                    )
+                    self._assumed_state = States.OFF if self._assumed_state == States.ON else States.ON
 
-                if state == media_player.States.OFF:
+                if state == States.OFF:
                     res = await self._device.turn_on()
                 else:
                     res = await self._device.turn_off()
@@ -303,3 +311,49 @@ class AppleTVMediaPlayer(AppleTVEntity, MediaPlayer):
                 res = await self._device.pause()
 
         return res if res is not None else StatusCodes.SERVER_ERROR
+
+    def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
+        """Return only the changed attributes."""
+        attributes: dict[str, Any] = {}
+
+        for attr in [
+            Attributes.STATE,
+            Attributes.MUTED,
+            Attributes.VOLUME,
+            Attributes.MEDIA_TYPE,
+            Attributes.MEDIA_IMAGE_URL,
+            Attributes.MEDIA_TITLE,
+            Attributes.MEDIA_ALBUM,
+            Attributes.MEDIA_ARTIST,
+            Attributes.MEDIA_POSITION,
+            Attributes.MEDIA_DURATION,
+            Attributes.MEDIA_POSITION_UPDATED_AT,
+            Attributes.SOURCE_LIST,
+            Attributes.SOURCE,
+            Attributes.SOUND_MODE_LIST,
+            Attributes.SOUND_MODE,
+            Attributes.SHUFFLE,
+            Attributes.REPEAT,
+            Attributes.MEDIA_ID,
+        ]:
+            if attr in update:
+                key_update_helper(attr, update[attr], attributes, self.attributes)
+
+        if Attributes.STATE in attributes and attributes[Attributes.STATE] == States.OFF:
+            AppleTVMediaPlayer.reset_media_data(attributes)
+
+        return attributes
+
+    @staticmethod
+    def reset_media_data(attributes: dict[str, Any]):
+        """Reset media metadata."""
+        attributes[Attributes.MEDIA_POSITION] = 0
+        attributes[Attributes.MEDIA_DURATION] = 0
+        attributes[Attributes.MEDIA_IMAGE_URL] = ""
+        attributes[Attributes.MEDIA_TITLE] = ""
+        attributes[Attributes.MEDIA_ARTIST] = ""
+        attributes[Attributes.MEDIA_ALBUM] = ""
+        attributes[Attributes.MEDIA_TYPE] = ""
+        attributes[Attributes.REPEAT] = RepeatMode.OFF
+        attributes[Attributes.SHUFFLE] = False
+        attributes[Attributes.SOURCE] = ""

--- a/intg-appletv/media_player.py
+++ b/intg-appletv/media_player.py
@@ -32,6 +32,27 @@ _LOG = logging.getLogger(__name__)
 ENABLE_REPEAT_FEAT = False
 ENABLE_SHUFFLE_FEAT = False
 
+_AVAILABLE_ATTRIBUTES = [
+    Attributes.STATE,
+    Attributes.MUTED,
+    Attributes.VOLUME,
+    Attributes.MEDIA_TYPE,
+    Attributes.MEDIA_IMAGE_URL,
+    Attributes.MEDIA_TITLE,
+    Attributes.MEDIA_ALBUM,
+    Attributes.MEDIA_ARTIST,
+    Attributes.MEDIA_POSITION,
+    Attributes.MEDIA_DURATION,
+    Attributes.MEDIA_POSITION_UPDATED_AT,
+    Attributes.SOURCE_LIST,
+    Attributes.SOURCE,
+    Attributes.SOUND_MODE_LIST,
+    Attributes.SOUND_MODE,
+    Attributes.SHUFFLE,
+    Attributes.REPEAT,
+    Attributes.MEDIA_ID,
+]
+
 
 class SimpleCommands(StrEnum):
     """Additional simple commands of the Apple TV not covered by media-player features."""
@@ -321,26 +342,7 @@ class AppleTVMediaPlayer(MediaPlayer, AppleTVEntity):
         """Return only the changed attributes."""
         attributes: dict[str, Any] = {}
 
-        for attr in [
-            Attributes.STATE,
-            Attributes.MUTED,
-            Attributes.VOLUME,
-            Attributes.MEDIA_TYPE,
-            Attributes.MEDIA_IMAGE_URL,
-            Attributes.MEDIA_TITLE,
-            Attributes.MEDIA_ALBUM,
-            Attributes.MEDIA_ARTIST,
-            Attributes.MEDIA_POSITION,
-            Attributes.MEDIA_DURATION,
-            Attributes.MEDIA_POSITION_UPDATED_AT,
-            Attributes.SOURCE_LIST,
-            Attributes.SOURCE,
-            Attributes.SOUND_MODE_LIST,
-            Attributes.SOUND_MODE,
-            Attributes.SHUFFLE,
-            Attributes.REPEAT,
-            Attributes.MEDIA_ID,
-        ]:
+        for attr in _AVAILABLE_ATTRIBUTES:
             if attr in update:
                 key_update_helper(attr, update[attr], attributes, self.attributes)
 

--- a/intg-appletv/media_player.py
+++ b/intg-appletv/media_player.py
@@ -139,6 +139,10 @@ class AppleTVMediaPlayer(MediaPlayer, AppleTVEntity):
         """Return the media-player attribute enum."""
         return Attributes
 
+    def state_from_media_player_state(self, state: States) -> States:
+        """Map media-player state. Pass through state."""
+        return state
+
     async def _playpause_in_screensaver(self) -> StatusCodes | None:
         """
         Mimic the original ATV remote behaviour (one can also call it a bunch of workarounds).

--- a/intg-appletv/media_player.py
+++ b/intg-appletv/media_player.py
@@ -10,7 +10,8 @@ import logging
 from enum import Enum, StrEnum
 from typing import Any, Type
 
-from config import AppleTVEntity, AtvDevice
+from config import AtvDevice
+from entities import AppleTVEntity
 from hid import UsagePage
 from hid.consumer_control_code import ConsumerControlCode
 from pyatv.const import PowerState

--- a/intg-appletv/media_player.py
+++ b/intg-appletv/media_player.py
@@ -103,7 +103,6 @@ class AppleTVMediaPlayer(MediaPlayer, AppleTVEntity):
         api: IntegrationAPI,
     ):
         """Initialize the class."""
-        # pylint: disable = R0801
         self._device = device
         self._assumed_state: States = States.OFF
         """Fallback state if device power state is not available."""
@@ -169,7 +168,6 @@ class AppleTVMediaPlayer(MediaPlayer, AppleTVEntity):
         """
         # tvOS 18.4 will raise an exception https://github.com/postlund/pyatv/issues/2648
         # Screensaver state is no longer accessible
-        # pylint: disable=W0718
         try:
             if self._device.media_state != States.PLAYING and await self._device.screensaver_active():
                 _LOG.debug("Screensaver is running, sending menu command for play_pause to exit")
@@ -181,7 +179,7 @@ class AppleTVMediaPlayer(MediaPlayer, AppleTVEntity):
                     return await self._device.cursor_select()
                 # Nothing was playing, only the screensaver was active
                 return StatusCodes.OK
-        except Exception:
+        except Exception:  # pylint: disable=W0718
             pass
         return None
 
@@ -343,7 +341,6 @@ class AppleTVMediaPlayer(MediaPlayer, AppleTVEntity):
         """
         attributes: dict[str, Any] = {}
 
-        # pylint: disable=R0801
         for attr in _AVAILABLE_ATTRIBUTES:
             if attr in update:
                 if force:

--- a/intg-appletv/media_player.py
+++ b/intg-appletv/media_player.py
@@ -337,10 +337,7 @@ class AppleTVMediaPlayer(MediaPlayer, AppleTVEntity):
         """
         Filter the given attributes from an ATV update and return only the related media-player entity values.
 
-        **Attention:**
-
-        - for ``States.OFF``: all media attributes are reset.
-        - the update dictionary can be modified in place!
+        **Attention:** for ``States.OFF``: all media attributes are reset.
 
         :param update: Dictionary containing the updated properties.
         :param force: If True, update attributes even if they haven't changed since the last update.

--- a/intg-appletv/media_player.py
+++ b/intg-appletv/media_player.py
@@ -148,7 +148,7 @@ class AppleTVMediaPlayer(MediaPlayer, AppleTVEntity):
         super().__init__(
             entity_id, config_device.name, features, attributes, device_class=DeviceClasses.TV, options=options
         )
-        AppleTVEntity.__init__(self, api)
+        AppleTVEntity.__init__(self, entity_id, api)
 
     @property
     def atv_id(self) -> str:
@@ -165,8 +165,6 @@ class AppleTVMediaPlayer(MediaPlayer, AppleTVEntity):
 
         Screensaver active: play/pause button exits screensaver. If a playback was paused, resume it.
 
-        :param state: the media-player state
-        :param device: the device
         :return: None if screensaver was not active, a StatusCode otherwise
         """
         # tvOS 18.4 will raise an exception https://github.com/postlund/pyatv/issues/2648

--- a/intg-appletv/remote.py
+++ b/intg-appletv/remote.py
@@ -89,7 +89,6 @@ def _main_ui_page() -> dict[str, Any]:
     }
 
 
-# pylint: disable=R0903
 class AppleTVRemote(Remote, AppleTVEntity):
     """Representation of an Apple TV Remote entity."""
 
@@ -97,7 +96,6 @@ class AppleTVRemote(Remote, AppleTVEntity):
         self, config_device: AtvDevice, device: tv.AppleTv, api: IntegrationAPI, mp_entity: AppleTVMediaPlayer
     ):
         """Initialize the class."""
-        # pylint: disable=R0801
         self._device = device
         self._media_player = mp_entity
         entity_id = create_entity_id(config_device.identifier, EntityTypes.REMOTE)
@@ -185,7 +183,7 @@ class AppleTVRemote(Remote, AppleTVEntity):
 
     async def command(self, cmd_id: str, params: dict[str, Any] | None = None, *, websocket: Any = None) -> StatusCodes:
         """Remote entity command handler."""
-        # pylint: disable=R0911,R0912,W0613
+        # pylint: disable=R0911,R0912
         match cmd_id:
             case Commands.ON:
                 return await self._media_player.command(media_player.Commands.ON, None)

--- a/intg-appletv/remote.py
+++ b/intg-appletv/remote.py
@@ -90,25 +90,6 @@ def _main_ui_page() -> dict[str, Any]:
     }
 
 
-def _state_from_media_player_state(state: media_player.States) -> ucapi.remote.States:
-    """Map media-player state to remote state."""
-    match state:
-        case (
-            media_player.States.ON
-            | media_player.States.BUFFERING
-            | media_player.States.PAUSED
-            | media_player.States.PLAYING
-            | media_player.States.STANDBY
-        ):
-            return ucapi.remote.States.ON
-        case media_player.States.OFF:
-            return ucapi.remote.States.OFF
-        case media_player.States.UNAVAILABLE:
-            return ucapi.remote.States.UNAVAILABLE
-        case _:
-            return ucapi.remote.States.UNKNOWN
-
-
 # pylint: disable=R0903
 class AppleTVRemote(Remote, AppleTVEntity):
     """Representation of an Apple TV Remote entity."""
@@ -148,7 +129,7 @@ class AppleTVRemote(Remote, AppleTVEntity):
             entity_id,
             f"{config_device.name} Remote",
             [Features.SEND_CMD, Features.ON_OFF, Features.TOGGLE],
-            attributes={Attributes.STATE: _state_from_media_player_state(device.media_state)},
+            attributes={Attributes.STATE: self.state_from_media_player_state(device.media_state)},
             simple_commands=simple_commands,
             button_mapping=REMOTE_BUTTONS_MAPPING,
             ui_pages=[_main_ui_page()],
@@ -165,11 +146,29 @@ class AppleTVRemote(Remote, AppleTVEntity):
         """Return the remote-entity attribute enum."""
         return Attributes
 
+    def state_from_media_player_state(self, state: media_player.States) -> ucapi.remote.States:
+        """Map media-player state to remote state."""
+        match state:
+            case (
+                media_player.States.ON
+                | media_player.States.BUFFERING
+                | media_player.States.PAUSED
+                | media_player.States.PLAYING
+                | media_player.States.STANDBY
+            ):
+                return ucapi.remote.States.ON
+            case media_player.States.OFF:
+                return ucapi.remote.States.OFF
+            case media_player.States.UNAVAILABLE:
+                return ucapi.remote.States.UNAVAILABLE
+            case _:
+                return ucapi.remote.States.UNKNOWN
+
     def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
         """Return only the changed attributes (state mapped to remote state)."""
         attributes: dict[str, Any] = {}
         if media_player.Attributes.STATE in update:
-            state = _state_from_media_player_state(update[media_player.Attributes.STATE])
+            state = self.state_from_media_player_state(update[media_player.Attributes.STATE])
             key_update_helper(Attributes.STATE, state, attributes, self.attributes)
         return attributes
 

--- a/intg-appletv/remote.py
+++ b/intg-appletv/remote.py
@@ -162,24 +162,24 @@ class AppleTVRemote(Remote, AppleTVEntity):
         """
         Filter the given attributes from an ATV update and return only the related remote-entity values.
 
-        **Attention:** the update dictionary can be modified in place!
-
         :param update: Dictionary containing the updated properties.
         :param force: If True, update attributes even if they haven't changed since the last update.
         :return: Dictionary containing only the changed attributes.
         """
         attributes: dict[str, Any] = {}
-        if media_player.Attributes.STATE in update:
-            update[media_player.Attributes.STATE] = self.state_from_media_player_state(
-                update[media_player.Attributes.STATE]
-            )
 
         for attr in Attributes:
-            if attr in update:
+            value = None
+            if attr == Attributes.STATE and media_player.Attributes.STATE in update:
+                value = self.state_from_media_player_state(update[media_player.Attributes.STATE])
+            elif attr in update:
+                value = update[attr]
+
+            if value is not None:
                 if force:
-                    attributes[attr] = update[attr]
+                    attributes[attr] = value
                 else:
-                    key_update_helper(attr, update[attr], attributes, self.attributes)
+                    key_update_helper(attr, value, attributes, self.attributes)
 
         return attributes
 

--- a/intg-appletv/remote.py
+++ b/intg-appletv/remote.py
@@ -133,7 +133,7 @@ class AppleTVRemote(Remote, AppleTVEntity):
             button_mapping=REMOTE_BUTTONS_MAPPING,
             ui_pages=[_main_ui_page()],
         )
-        AppleTVEntity.__init__(self, api)
+        AppleTVEntity.__init__(self, entity_id, api)
 
     @property
     def atv_id(self) -> str:

--- a/intg-appletv/remote.py
+++ b/intg-appletv/remote.py
@@ -6,8 +6,7 @@ Remote entity functions.
 """
 
 import logging
-from enum import Enum
-from typing import Any, Type
+from typing import Any
 
 import tv
 import ucapi.remote
@@ -141,11 +140,6 @@ class AppleTVRemote(Remote, AppleTVEntity):
         """Return the device identifier."""
         return self._device.identifier
 
-    @property
-    def attribute_enum(self) -> Type[Enum]:
-        """Return the remote-entity attribute enum."""
-        return Attributes
-
     def state_from_media_player_state(self, state: media_player.States) -> ucapi.remote.States:
         """Map media-player state to remote state."""
         match state:
@@ -164,12 +158,29 @@ class AppleTVRemote(Remote, AppleTVEntity):
             case _:
                 return ucapi.remote.States.UNKNOWN
 
-    def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
-        """Return only the changed attributes (state mapped to remote state)."""
+    def filter_attributes(self, update: dict[str, Any], *, force: bool = False) -> dict[str, Any]:
+        """
+        Filter the given attributes from an ATV update and return only the related remote-entity values.
+
+        **Attention:** the update dictionary can be modified in place!
+
+        :param update: Dictionary containing the updated properties.
+        :param force: If True, update attributes even if they haven't changed since the last update.
+        :return: Dictionary containing only the changed attributes.
+        """
         attributes: dict[str, Any] = {}
         if media_player.Attributes.STATE in update:
-            state = self.state_from_media_player_state(update[media_player.Attributes.STATE])
-            key_update_helper(Attributes.STATE, state, attributes, self.attributes)
+            update[media_player.Attributes.STATE] = self.state_from_media_player_state(
+                update[media_player.Attributes.STATE]
+            )
+
+        for attr in Attributes:
+            if attr in update:
+                if force:
+                    attributes[attr] = update[attr]
+                else:
+                    key_update_helper(attr, update[attr], attributes, self.attributes)
+
         return attributes
 
     async def command(self, cmd_id: str, params: dict[str, Any] | None = None, *, websocket: Any = None) -> StatusCodes:

--- a/intg-appletv/remote.py
+++ b/intg-appletv/remote.py
@@ -11,7 +11,8 @@ from typing import Any, Type
 
 import tv
 import ucapi.remote
-from config import AppleTVEntity, AtvDevice, create_entity_id
+from config import AtvDevice, create_entity_id
+from entities import AppleTVEntity
 from media_player import AppleTVMediaPlayer, SimpleCommands
 from ucapi import EntityTypes, IntegrationAPI, Remote, StatusCodes, media_player
 from ucapi.media_player import Commands as MediaPlayerCommands

--- a/intg-appletv/remote.py
+++ b/intg-appletv/remote.py
@@ -6,16 +6,18 @@ Remote entity functions.
 """
 
 import logging
-from typing import Any
+from enum import Enum
+from typing import Any, Type
 
 import tv
 import ucapi.remote
 from config import AppleTVEntity, AtvDevice, create_entity_id
 from media_player import AppleTVMediaPlayer, SimpleCommands
-from ucapi import EntityTypes, Remote, StatusCodes, media_player
+from ucapi import EntityTypes, IntegrationAPI, Remote, StatusCodes, media_player
 from ucapi.media_player import Commands as MediaPlayerCommands
 from ucapi.remote import Attributes, Commands, Features
 from ucapi.ui import Buttons
+from utils import key_update_helper
 
 _LOG = logging.getLogger(__name__)
 
@@ -106,19 +108,13 @@ def _state_from_media_player_state(state: media_player.States) -> ucapi.remote.S
             return ucapi.remote.States.UNKNOWN
 
 
-def _key_update(key: str, value: Any, attributes: dict, original: dict) -> dict:
-    if value is None:
-        return attributes
-    if key not in original or original[key] != value:
-        attributes[key] = value
-    return attributes
-
-
 # pylint: disable=R0903
-class AppleTVRemote(AppleTVEntity, Remote):
+class AppleTVRemote(Remote, AppleTVEntity):
     """Representation of an Apple TV Remote entity."""
 
-    def __init__(self, config_device: AtvDevice, device: tv.AppleTv, mp_entity: AppleTVMediaPlayer):
+    def __init__(
+        self, config_device: AtvDevice, device: tv.AppleTv, api: IntegrationAPI, mp_entity: AppleTVMediaPlayer
+    ):
         """Initialize the class."""
         # pylint: disable=R0801
         self._device = device
@@ -156,18 +152,24 @@ class AppleTVRemote(AppleTVEntity, Remote):
             button_mapping=REMOTE_BUTTONS_MAPPING,
             ui_pages=[_main_ui_page()],
         )
+        AppleTVEntity.__init__(self, api)
 
     @property
-    def deviceid(self) -> str:
+    def atv_id(self) -> str:
         """Return the device identifier."""
         return self._device.identifier
+
+    @property
+    def attribute_enum(self) -> Type[Enum]:
+        """Return the remote-entity attribute enum."""
+        return Attributes
 
     def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
         """Return only the changed attributes (state mapped to remote state)."""
         attributes: dict[str, Any] = {}
         if media_player.Attributes.STATE in update:
             state = _state_from_media_player_state(update[media_player.Attributes.STATE])
-            _key_update(Attributes.STATE, state, attributes, self.attributes)
+            key_update_helper(Attributes.STATE, state, attributes, self.attributes)
         return attributes
 
     async def command(self, cmd_id: str, params: dict[str, Any] | None = None, *, websocket: Any = None) -> StatusCodes:

--- a/intg-appletv/selector.py
+++ b/intg-appletv/selector.py
@@ -89,11 +89,15 @@ class AppleTVSelect(Select, AppleTVEntity):
             Attributes.STATE: States.ON,
         }
 
+    def state_from_media_player_state(self, state: States) -> States:
+        """Map media-player state to select state."""
+        return SELECTOR_STATE_MAPPING.get(state, States.UNKNOWN)
+
     def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
         """Return only the changed attributes."""
         attributes: dict[str, Any] = {}
         if ucapi.media_player.Attributes.STATE in update:
-            new_state = SELECTOR_STATE_MAPPING.get(update[ucapi.media_player.Attributes.STATE], States.UNKNOWN)
+            new_state = self.state_from_media_player_state(update[ucapi.media_player.Attributes.STATE])
             if new_state != self._state:
                 self._state = new_state
                 attributes[Attributes.STATE] = self._state

--- a/intg-appletv/selector.py
+++ b/intg-appletv/selector.py
@@ -6,12 +6,14 @@ Select entity functions.
 """
 
 import logging
+from abc import abstractmethod
 from enum import Enum
 from typing import Any, Type
 
 import tv
 import ucapi
-from config import AppleTVEntity, AtvDevice, create_entity_id
+from config import AtvDevice, create_entity_id
+from entities import AppleTVEntity
 from ucapi import EntityTypes, IntegrationAPI, Select, StatusCodes
 from ucapi.api_definitions import CommandHandler
 from ucapi.media_player import States as MediaStates
@@ -69,14 +71,14 @@ class AppleTVSelect(Select, AppleTVEntity):
         return Attributes
 
     @property
+    @abstractmethod
     def current_option(self) -> str:
         """Return select value."""
-        raise NotImplementedError()
 
     @property
+    @abstractmethod
     def select_options(self) -> list[str]:
         """Return selection list."""
-        raise NotImplementedError()
 
     @property
     def all_attributes(self) -> dict[str, Any]:
@@ -89,18 +91,15 @@ class AppleTVSelect(Select, AppleTVEntity):
 
     def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
         """Return only the changed attributes."""
-        # TODO(#118) probably needs to be refactored
-        if update:
-            attributes: dict[str, Any] = {}
-            if ucapi.media_player.Attributes.STATE in update:
-                new_state = SELECTOR_STATE_MAPPING.get(update[ucapi.media_player.Attributes.STATE], States.UNKNOWN)
-                if new_state != self._state:
-                    self._state = new_state
-                    attributes[Attributes.STATE] = self._state
-            if self.SELECT_NAME in update:
-                attributes |= update[self.SELECT_NAME]
-            return attributes
-        return self.all_attributes
+        attributes: dict[str, Any] = {}
+        if ucapi.media_player.Attributes.STATE in update:
+            new_state = SELECTOR_STATE_MAPPING.get(update[ucapi.media_player.Attributes.STATE], States.UNKNOWN)
+            if new_state != self._state:
+                self._state = new_state
+                attributes[Attributes.STATE] = self._state
+        if self.SELECT_NAME in update:
+            attributes |= update[self.SELECT_NAME]
+        return attributes
 
     async def command(self, cmd_id: str, params: dict[str, Any] | None = None, *, websocket: Any) -> StatusCodes:
         """Process selector command."""

--- a/intg-appletv/selector.py
+++ b/intg-appletv/selector.py
@@ -100,11 +100,19 @@ class AppleTVSelect(Select, AppleTVEntity):
             new_state = self.state_from_media_player_state(update[ucapi.media_player.Attributes.STATE])
             if force or new_state != self.attributes.get(Attributes.STATE):
                 attributes[Attributes.STATE] = new_state
-        # TODO untangle select-entity attribute updates. Check for select value change.
+        # TODO untangle select-entity attribute updates.
         if self.SELECT_NAME in update:
-            # make sure select-entity is available if data changes
+            if Attributes.CURRENT_OPTION in update[self.SELECT_NAME]:
+                if force or update[self.SELECT_NAME][Attributes.CURRENT_OPTION] != self.attributes.get(
+                    Attributes.CURRENT_OPTION
+                ):
+                    attributes[Attributes.CURRENT_OPTION] = update[self.SELECT_NAME][Attributes.CURRENT_OPTION]
+            if Attributes.OPTIONS in update[self.SELECT_NAME]:
+                if force or update[self.SELECT_NAME][Attributes.OPTIONS] != self.attributes.get(Attributes.OPTIONS):
+                    attributes[Attributes.OPTIONS] = update[self.SELECT_NAME][Attributes.OPTIONS]
+        # make sure select-entity is available if data changes
+        if attributes and Attributes.STATE not in update:
             attributes[Attributes.STATE] = States.ON
-            attributes |= update[self.SELECT_NAME]
         return attributes
 
     async def command(self, cmd_id: str, params: dict[str, Any] | None = None, *, websocket: Any) -> StatusCodes:

--- a/intg-appletv/selector.py
+++ b/intg-appletv/selector.py
@@ -55,7 +55,6 @@ class AppleTVSelect(Select, AppleTVEntity):
         # pylint: disable = R0801
         self._config_device = config_device
         self._device: tv.AppleTv = device
-        self._state: States = States.ON
         self._select_handler: CommandHandler = select_handler
         super().__init__(identifier=entity_id, name=name, attributes=self.all_attributes)
         AppleTVEntity.__init__(self, api)
@@ -98,10 +97,11 @@ class AppleTVSelect(Select, AppleTVEntity):
         attributes: dict[str, Any] = {}
         if ucapi.media_player.Attributes.STATE in update:
             new_state = self.state_from_media_player_state(update[ucapi.media_player.Attributes.STATE])
-            if new_state != self._state:
-                self._state = new_state
-                attributes[Attributes.STATE] = self._state
+            if new_state != self.attributes.get(Attributes.STATE):
+                attributes[Attributes.STATE] = new_state
         if self.SELECT_NAME in update:
+            # make sure select-entity is available if data changes
+            attributes[Attributes.STATE] = States.ON
             attributes |= update[self.SELECT_NAME]
         return attributes
 

--- a/intg-appletv/selector.py
+++ b/intg-appletv/selector.py
@@ -89,8 +89,6 @@ class AppleTVSelect(Select, AppleTVEntity):
         """
         Filter the given attributes from an ATV update and return only the related select-entity values.
 
-        **Attention:** the update dictionary can be modified in place!
-
         :param update: Dictionary containing the updated properties.
         :param force: If True, update attributes even if they haven't changed since the last update.
         :return: Dictionary containing only the changed attributes.

--- a/intg-appletv/selector.py
+++ b/intg-appletv/selector.py
@@ -6,12 +6,13 @@ Select entity functions.
 """
 
 import logging
-from typing import Any
+from enum import Enum
+from typing import Any, Type
 
 import tv
 import ucapi
 from config import AppleTVEntity, AtvDevice, create_entity_id
-from ucapi import EntityTypes, Select, StatusCodes
+from ucapi import EntityTypes, IntegrationAPI, Select, StatusCodes
 from ucapi.api_definitions import CommandHandler
 from ucapi.media_player import States as MediaStates
 from ucapi.select import Attributes, Commands, States
@@ -32,7 +33,7 @@ SELECTOR_STATE_MAPPING = {
 
 
 # pylint: disable=W1405,R0801
-class AppleTVSelect(AppleTVEntity, Select):
+class AppleTVSelect(Select, AppleTVEntity):
     """Representation of a Apple TV select entity."""
 
     ENTITY_NAME = "select"
@@ -45,6 +46,7 @@ class AppleTVSelect(AppleTVEntity, Select):
         name: str | dict[str, str],
         config_device: AtvDevice,
         device: tv.AppleTv,
+        api: IntegrationAPI,
         select_handler: CommandHandler,
     ):
         """Initialize the class."""
@@ -54,11 +56,17 @@ class AppleTVSelect(AppleTVEntity, Select):
         self._state: States = States.ON
         self._select_handler: CommandHandler = select_handler
         super().__init__(identifier=entity_id, name=name, attributes=self.all_attributes)
+        AppleTVEntity.__init__(self, api)
 
     @property
-    def deviceid(self) -> str:
+    def atv_id(self) -> str:
         """Return device identifier."""
         return self._device.identifier
+
+    @property
+    def attribute_enum(self) -> Type[Enum]:
+        """Return the select-entity attribute enum."""
+        return Attributes
 
     @property
     def current_option(self) -> str:
@@ -79,12 +87,13 @@ class AppleTVSelect(AppleTVEntity, Select):
             Attributes.STATE: States.ON,
         }
 
-    def update_attributes(self, update: dict[str, Any] | None = None) -> dict[str, Any] | None:
-        """Return updated selector value from full update if provided or selector value if no update is provided."""
+    def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
+        """Return only the changed attributes."""
+        # TODO(#118) probably needs to be refactored
         if update:
             attributes: dict[str, Any] = {}
             if ucapi.media_player.Attributes.STATE in update:
-                new_state = SELECTOR_STATE_MAPPING.get(update[ucapi.media_player.Attributes.STATE])
+                new_state = SELECTOR_STATE_MAPPING.get(update[ucapi.media_player.Attributes.STATE], States.UNKNOWN)
                 if new_state != self._state:
                     self._state = new_state
                     attributes[Attributes.STATE] = self._state
@@ -149,7 +158,12 @@ class AppSelect(AppleTVSelect):
     ENTITY_NAME = "app"
     SELECT_NAME = AppleTVSelects.SELECT_APP
 
-    def __init__(self, config_device: AtvDevice, device: tv.AppleTv):
+    def __init__(
+        self,
+        config_device: AtvDevice,
+        device: tv.AppleTv,
+        api: IntegrationAPI,
+    ):
         """Initialize the class."""
         # pylint: disable=W1405,R0801
         entity_id = f"{create_entity_id(config_device.identifier, EntityTypes.SELECT)}.{self.ENTITY_NAME}"
@@ -160,6 +174,7 @@ class AppSelect(AppleTVSelect):
             },
             config_device,
             device,
+            api,
             device.launch_app,
         )
 
@@ -180,7 +195,7 @@ class AudioOutputSelect(AppleTVSelect):
     ENTITY_NAME = "audio_output"
     SELECT_NAME = AppleTVSelects.SELECT_AUDIO_OUTPUT
 
-    def __init__(self, config_device: AtvDevice, device: tv.AppleTv):
+    def __init__(self, config_device: AtvDevice, device: tv.AppleTv, api: IntegrationAPI):
         """Initialize the class."""
         # pylint: disable=W1405,R0801
         entity_id = f"{create_entity_id(config_device.identifier, EntityTypes.SELECT)}.{self.ENTITY_NAME}"
@@ -191,6 +206,7 @@ class AudioOutputSelect(AppleTVSelect):
             },
             config_device,
             device,
+            api,
             device.set_output_device,
         )
 

--- a/intg-appletv/selector.py
+++ b/intg-appletv/selector.py
@@ -55,7 +55,7 @@ class AppleTVSelect(Select, AppleTVEntity):
         self._device: tv.AppleTv = device
         self._select_handler: CommandHandler = select_handler
         super().__init__(identifier=entity_id, name=name, attributes=self.all_attributes)
-        AppleTVEntity.__init__(self, api)
+        AppleTVEntity.__init__(self, entity_id, api)
 
     @property
     def atv_id(self) -> str:

--- a/intg-appletv/selector.py
+++ b/intg-appletv/selector.py
@@ -117,7 +117,7 @@ class AppleTVSelect(Select, AppleTVEntity):
         if cmd_id == Commands.SELECT_LAST and len(options) > 0:
             return await self._select_handler(options[len(options) - 1])
         if cmd_id == Commands.SELECT_NEXT and len(options) > 0:
-            cycle = params.get("cycle", False)
+            cycle = params.get("cycle", True) if params else True
             try:
                 index = options.index(self.current_option) + 1
                 if not cycle and index >= len(options):
@@ -135,7 +135,7 @@ class AppleTVSelect(Select, AppleTVEntity):
                 )
                 return StatusCodes.BAD_REQUEST
         if cmd_id == Commands.SELECT_PREVIOUS and len(options) > 0:
-            cycle = params.get("cycle", False)
+            cycle = params.get("cycle", True) if params else True
             try:
                 index = options.index(self.current_option) - 1
                 if not cycle and index < 0:

--- a/intg-appletv/selector.py
+++ b/intg-appletv/selector.py
@@ -13,12 +13,11 @@ from typing import Any, Type
 import tv
 import ucapi
 from config import AtvDevice, create_entity_id
-from entities import AppleTVEntity
+from entities import AppleTVEntity, AppleTVSelects
 from ucapi import EntityTypes, IntegrationAPI, Select, StatusCodes
 from ucapi.api_definitions import CommandHandler
 from ucapi.media_player import States as MediaStates
 from ucapi.select import Attributes, Commands, States
-from utils import AppleTVSelects
 
 _LOG = logging.getLogger(__name__)
 

--- a/intg-appletv/selector.py
+++ b/intg-appletv/selector.py
@@ -7,8 +7,7 @@ Select entity functions.
 
 import logging
 from abc import abstractmethod
-from enum import Enum
-from typing import Any, Type
+from typing import Any
 
 import tv
 import ucapi
@@ -21,8 +20,8 @@ from ucapi.select import Attributes, Commands, States
 
 _LOG = logging.getLogger(__name__)
 
-# pylint: disable=R0801
-SELECTOR_STATE_MAPPING = {
+# pylint should focus on the real Python issues! pylint: disable=R0801
+_SELECTOR_STATE_MAPPING = {
     MediaStates.OFF: States.ON,
     MediaStates.ON: States.ON,
     MediaStates.STANDBY: States.ON,
@@ -64,11 +63,6 @@ class AppleTVSelect(Select, AppleTVEntity):
         return self._device.identifier
 
     @property
-    def attribute_enum(self) -> Type[Enum]:
-        """Return the select-entity attribute enum."""
-        return Attributes
-
-    @property
     @abstractmethod
     def current_option(self) -> str:
         """Return select value."""
@@ -89,15 +83,24 @@ class AppleTVSelect(Select, AppleTVEntity):
 
     def state_from_media_player_state(self, state: States) -> States:
         """Map media-player state to select state."""
-        return SELECTOR_STATE_MAPPING.get(state, States.UNKNOWN)
+        return _SELECTOR_STATE_MAPPING.get(state, States.UNKNOWN)
 
-    def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
-        """Return only the changed attributes."""
+    def filter_attributes(self, update: dict[str, Any], *, force: bool = False) -> dict[str, Any]:
+        """
+        Filter the given attributes from an ATV update and return only the related select-entity values.
+
+        **Attention:** the update dictionary can be modified in place!
+
+        :param update: Dictionary containing the updated properties.
+        :param force: If True, update attributes even if they haven't changed since the last update.
+        :return: Dictionary containing only the changed attributes.
+        """
         attributes: dict[str, Any] = {}
         if ucapi.media_player.Attributes.STATE in update:
             new_state = self.state_from_media_player_state(update[ucapi.media_player.Attributes.STATE])
-            if new_state != self.attributes.get(Attributes.STATE):
+            if force or new_state != self.attributes.get(Attributes.STATE):
                 attributes[Attributes.STATE] = new_state
+        # TODO untangle select-entity attribute updates. Check for select value change.
         if self.SELECT_NAME in update:
             # make sure select-entity is available if data changes
             attributes[Attributes.STATE] = States.ON

--- a/intg-appletv/selector.py
+++ b/intg-appletv/selector.py
@@ -32,25 +32,23 @@ _SELECTOR_STATE_MAPPING = {
 }
 
 
-# pylint: disable=W1405,R0801
 class AppleTVSelect(Select, AppleTVEntity):
     """Representation of a Apple TV select entity."""
 
     ENTITY_NAME = "select"
     SELECT_NAME: AppleTVSelects
 
-    # pylint: disable=R0917
     def __init__(
         self,
         entity_id: str,
         name: str | dict[str, str],
         config_device: AtvDevice,
         device: tv.AppleTv,
+        *,
         api: IntegrationAPI,
         select_handler: CommandHandler,
     ):
         """Initialize the class."""
-        # pylint: disable = R0801
         self._config_device = config_device
         self._device: tv.AppleTv = device
         self._select_handler: CommandHandler = select_handler
@@ -176,7 +174,6 @@ class AppSelect(AppleTVSelect):
         api: IntegrationAPI,
     ):
         """Initialize the class."""
-        # pylint: disable=W1405,R0801
         entity_id = f"{create_entity_id(config_device.identifier, EntityTypes.SELECT)}.{self.ENTITY_NAME}"
         super().__init__(
             entity_id,
@@ -185,8 +182,8 @@ class AppSelect(AppleTVSelect):
             },
             config_device,
             device,
-            api,
-            device.launch_app,
+            api=api,
+            select_handler=device.launch_app,
         )
 
     @property
@@ -208,7 +205,6 @@ class AudioOutputSelect(AppleTVSelect):
 
     def __init__(self, config_device: AtvDevice, device: tv.AppleTv, api: IntegrationAPI):
         """Initialize the class."""
-        # pylint: disable=W1405,R0801
         entity_id = f"{create_entity_id(config_device.identifier, EntityTypes.SELECT)}.{self.ENTITY_NAME}"
         super().__init__(
             entity_id,
@@ -217,8 +213,8 @@ class AudioOutputSelect(AppleTVSelect):
             },
             config_device,
             device,
-            api,
-            device.set_output_device,
+            api=api,
+            select_handler=device.set_output_device,
         )
 
     @property

--- a/intg-appletv/sensor.py
+++ b/intg-appletv/sensor.py
@@ -88,11 +88,15 @@ class AppleTVSensor(Sensor, AppleTVEntity):
             Attributes.STATE: SENSOR_STATE_MAPPING.get(self._device.media_state),
         }
 
+    def state_from_media_player_state(self, state: States) -> States:
+        """Map media-player state to sensor state."""
+        return SENSOR_STATE_MAPPING.get(state, States.UNKNOWN)
+
     def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
         """Return only the changed attributes."""
         attributes: dict[str, Any] = {}
         if ucapi.media_player.Attributes.STATE in update:
-            new_state = SENSOR_STATE_MAPPING.get(update[ucapi.media_player.Attributes.STATE], States.UNKNOWN)
+            new_state = self.state_from_media_player_state(update[ucapi.media_player.Attributes.STATE])
             if new_state != self._state:
                 self._state = new_state
                 attributes[Attributes.STATE] = self._state

--- a/intg-appletv/sensor.py
+++ b/intg-appletv/sensor.py
@@ -56,7 +56,6 @@ class AppleTVSensor(Sensor, AppleTVEntity):
         features = []
 
         self._config_device = config_device
-        self._state: States = States.UNAVAILABLE
         super().__init__(entity_id, name, features, self.all_attributes, device_class=device_class, options=options)
         AppleTVEntity.__init__(self, api)
 
@@ -69,11 +68,6 @@ class AppleTVSensor(Sensor, AppleTVEntity):
     def attribute_enum(self) -> Type[Enum]:
         """Return the sensor-entity attribute enum."""
         return Attributes
-
-    @property
-    def state(self) -> States:
-        """Return sensor state."""
-        return self._state
 
     @property
     @abstractmethod
@@ -97,10 +91,11 @@ class AppleTVSensor(Sensor, AppleTVEntity):
         attributes: dict[str, Any] = {}
         if ucapi.media_player.Attributes.STATE in update:
             new_state = self.state_from_media_player_state(update[ucapi.media_player.Attributes.STATE])
-            if new_state != self._state:
-                self._state = new_state
-                attributes[Attributes.STATE] = self._state
+            if new_state != self.attributes.get(Attributes.STATE):
+                attributes[Attributes.STATE] = new_state
         if self.SENSOR_NAME in update:
+            # make sure sensor-entity is available if data changes
+            attributes[Attributes.STATE] = States.ON
             attributes[Attributes.VALUE] = update[self.SENSOR_NAME]
         return attributes
 

--- a/intg-appletv/sensor.py
+++ b/intg-appletv/sensor.py
@@ -93,11 +93,11 @@ class AppleTVSensor(Sensor, AppleTVEntity):
             new_state = self.state_from_media_player_state(update[ucapi.media_player.Attributes.STATE])
             if force or new_state != self.attributes.get(Attributes.STATE):
                 attributes[Attributes.STATE] = new_state
-        # TODO check for sensor value change
         if self.SENSOR_NAME in update:
-            # make sure sensor-entity is available if data changes
-            attributes[Attributes.STATE] = States.ON
-            attributes[Attributes.VALUE] = update[self.SENSOR_NAME]
+            if force or update[self.SENSOR_NAME] != self.attributes.get(Attributes.VALUE):
+                # make sure sensor-entity is available if data changes
+                attributes[Attributes.STATE] = States.ON
+                attributes[Attributes.VALUE] = update[self.SENSOR_NAME]
         return attributes
 
 

--- a/intg-appletv/sensor.py
+++ b/intg-appletv/sensor.py
@@ -82,8 +82,6 @@ class AppleTVSensor(Sensor, AppleTVEntity):
         """
         Filter the given attributes from an ATV update and return only the related select-entity values.
 
-        **Attention:** the update dictionary can be modified in place!
-
         :param update: Dictionary containing the updated properties.
         :param force: If True, update attributes even if they haven't changed since the last update.
         :return: Dictionary containing only the changed attributes.

--- a/intg-appletv/sensor.py
+++ b/intg-appletv/sensor.py
@@ -54,7 +54,7 @@ class AppleTVSensor(Sensor, AppleTVEntity):
 
         self._config_device = config_device
         super().__init__(entity_id, name, features, self.all_attributes, device_class=device_class, options=options)
-        AppleTVEntity.__init__(self, api)
+        AppleTVEntity.__init__(self, entity_id, api)
 
     @property
     def atv_id(self) -> str:

--- a/intg-appletv/sensor.py
+++ b/intg-appletv/sensor.py
@@ -6,12 +6,13 @@ Sensor entity functions.
 """
 
 import logging
-from typing import Any
+from enum import Enum
+from typing import Any, Type
 
 import tv
 import ucapi.media_player
 from config import AppleTVEntity, AtvDevice, create_entity_id
-from ucapi import EntityTypes, Sensor
+from ucapi import EntityTypes, IntegrationAPI, Sensor
 from ucapi.media_player import States as MediaStates
 from ucapi.sensor import Attributes, DeviceClasses, Options, States
 from utils import AppleTVSensors
@@ -31,7 +32,7 @@ SENSOR_STATE_MAPPING = {
 
 
 # pylint: disable=R0917,R0801
-class AppleTVSensor(AppleTVEntity, Sensor):
+class AppleTVSensor(Sensor, AppleTVEntity):
     """Representation of a AppleTV Sensor entity."""
 
     ENTITY_NAME = "sensor"
@@ -43,6 +44,8 @@ class AppleTVSensor(AppleTVEntity, Sensor):
         name: str | dict[str, str],
         config_device: AtvDevice,
         device: tv.AppleTv,
+        api: IntegrationAPI,
+        *,
         options: dict[Options, Any] | None = None,
         device_class: DeviceClasses = DeviceClasses.CUSTOM,
     ):
@@ -53,11 +56,17 @@ class AppleTVSensor(AppleTVEntity, Sensor):
         self._config_device = config_device
         self._state: States = States.UNAVAILABLE
         super().__init__(entity_id, name, features, self.all_attributes, device_class=device_class, options=options)
+        AppleTVEntity.__init__(self, api)
 
     @property
-    def deviceid(self) -> str:
+    def atv_id(self) -> str:
         """Return device identifier."""
         return self._device.identifier
+
+    @property
+    def attribute_enum(self) -> Type[Enum]:
+        """Return the sensor-entity attribute enum."""
+        return Attributes
 
     @property
     def state(self) -> States:
@@ -77,12 +86,13 @@ class AppleTVSensor(AppleTVEntity, Sensor):
             Attributes.STATE: SENSOR_STATE_MAPPING.get(self._device.media_state),
         }
 
-    def update_attributes(self, update: dict[str, Any] | None = None) -> dict[str, Any] | None:
-        """Return updated sensor value from full update if provided or sensor value if no update is provided."""
+    def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
+        """Return only the changed attributes."""
         attributes: dict[str, Any] = {}
+        # TODO(#118) probably needs to be refactored
         if update:
             if ucapi.media_player.Attributes.STATE in update:
-                new_state = SENSOR_STATE_MAPPING.get(update[ucapi.media_player.Attributes.STATE])
+                new_state = SENSOR_STATE_MAPPING.get(update[ucapi.media_player.Attributes.STATE], States.UNKNOWN)
                 if new_state != self._state:
                     self._state = new_state
                     attributes[Attributes.STATE] = self._state
@@ -98,7 +108,12 @@ class AppSensor(AppleTVSensor):
     ENTITY_NAME = "app"
     SENSOR_NAME = AppleTVSensors.SENSOR_APP
 
-    def __init__(self, config_device: AtvDevice, device: tv.AppleTv):
+    def __init__(
+        self,
+        config_device: AtvDevice,
+        device: tv.AppleTv,
+        api: IntegrationAPI,
+    ):
         """Initialize the class."""
         entity_id = f"{create_entity_id(config_device.identifier, EntityTypes.SENSOR)}.{self.ENTITY_NAME}"
         super().__init__(
@@ -108,6 +123,7 @@ class AppSensor(AppleTVSensor):
             },
             config_device,
             device,
+            api,
         )
 
     @property
@@ -122,7 +138,12 @@ class AudioOutputSensor(AppleTVSensor):
     ENTITY_NAME = "audio_output"
     SENSOR_NAME = AppleTVSensors.SENSOR_AUDIO_OUTPUT
 
-    def __init__(self, config_device: AtvDevice, device: tv.AppleTv):
+    def __init__(
+        self,
+        config_device: AtvDevice,
+        device: tv.AppleTv,
+        api: IntegrationAPI,
+    ):
         """Initialize the class."""
         entity_id = f"{create_entity_id(config_device.identifier, EntityTypes.SENSOR)}.{self.ENTITY_NAME}"
         super().__init__(
@@ -132,6 +153,7 @@ class AudioOutputSensor(AppleTVSensor):
             },
             config_device,
             device,
+            api,
         )
 
     @property

--- a/intg-appletv/sensor.py
+++ b/intg-appletv/sensor.py
@@ -94,7 +94,7 @@ class AppleTVSensor(Sensor, AppleTVEntity):
         if self.SENSOR_NAME in update:
             if force or update[self.SENSOR_NAME] != self.attributes.get(Attributes.VALUE):
                 # make sure sensor-entity is available if data changes
-                attributes[Attributes.STATE] = States.ON
+                attributes.setdefault(Attributes.STATE, States.ON)
                 attributes[Attributes.VALUE] = update[self.SENSOR_NAME]
         return attributes
 

--- a/intg-appletv/sensor.py
+++ b/intg-appletv/sensor.py
@@ -13,11 +13,10 @@ from typing import Any, Type
 import tv
 import ucapi.media_player
 from config import AtvDevice, create_entity_id
-from entities import AppleTVEntity
+from entities import AppleTVEntity, AppleTVSensors
 from ucapi import EntityTypes, IntegrationAPI, Sensor
 from ucapi.media_player import States as MediaStates
 from ucapi.sensor import Attributes, DeviceClasses, Options, States
-from utils import AppleTVSensors
 
 _LOG = logging.getLogger(__name__)
 

--- a/intg-appletv/sensor.py
+++ b/intg-appletv/sensor.py
@@ -30,7 +30,6 @@ _SENSOR_STATE_MAPPING = {
 }
 
 
-# pylint: disable=R0917,R0801
 class AppleTVSensor(Sensor, AppleTVEntity):
     """Representation of a AppleTV Sensor entity."""
 
@@ -43,8 +42,8 @@ class AppleTVSensor(Sensor, AppleTVEntity):
         name: str | dict[str, str],
         config_device: AtvDevice,
         device: tv.AppleTv,
-        api: IntegrationAPI,
         *,
+        api: IntegrationAPI,
         options: dict[Options, Any] | None = None,
         device_class: DeviceClasses = DeviceClasses.CUSTOM,
     ):
@@ -120,7 +119,7 @@ class AppSensor(AppleTVSensor):
             },
             config_device,
             device,
-            api,
+            api=api,
         )
 
     @property
@@ -150,7 +149,7 @@ class AudioOutputSensor(AppleTVSensor):
             },
             config_device,
             device,
-            api,
+            api=api,
         )
 
     @property

--- a/intg-appletv/sensor.py
+++ b/intg-appletv/sensor.py
@@ -7,8 +7,7 @@ Sensor entity functions.
 
 import logging
 from abc import abstractmethod
-from enum import Enum
-from typing import Any, Type
+from typing import Any
 
 import tv
 import ucapi.media_player
@@ -20,8 +19,7 @@ from ucapi.sensor import Attributes, DeviceClasses, Options, States
 
 _LOG = logging.getLogger(__name__)
 
-# pylint: disable=R0801
-SENSOR_STATE_MAPPING = {
+_SENSOR_STATE_MAPPING = {
     MediaStates.OFF: States.ON,
     MediaStates.ON: States.ON,
     MediaStates.STANDBY: States.ON,
@@ -64,11 +62,6 @@ class AppleTVSensor(Sensor, AppleTVEntity):
         return self._device.identifier
 
     @property
-    def attribute_enum(self) -> Type[Enum]:
-        """Return the sensor-entity attribute enum."""
-        return Attributes
-
-    @property
     @abstractmethod
     def sensor_value(self) -> str:
         """Return sensor value."""
@@ -78,20 +71,29 @@ class AppleTVSensor(Sensor, AppleTVEntity):
         """Return all attributes."""
         return {
             Attributes.VALUE: self.sensor_value,
-            Attributes.STATE: SENSOR_STATE_MAPPING.get(self._device.media_state),
+            Attributes.STATE: _SENSOR_STATE_MAPPING.get(self._device.media_state),
         }
 
     def state_from_media_player_state(self, state: States) -> States:
         """Map media-player state to sensor state."""
-        return SENSOR_STATE_MAPPING.get(state, States.UNKNOWN)
+        return _SENSOR_STATE_MAPPING.get(state, States.UNKNOWN)
 
-    def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
-        """Return only the changed attributes."""
+    def filter_attributes(self, update: dict[str, Any], *, force: bool = False) -> dict[str, Any]:
+        """
+        Filter the given attributes from an ATV update and return only the related select-entity values.
+
+        **Attention:** the update dictionary can be modified in place!
+
+        :param update: Dictionary containing the updated properties.
+        :param force: If True, update attributes even if they haven't changed since the last update.
+        :return: Dictionary containing only the changed attributes.
+        """
         attributes: dict[str, Any] = {}
         if ucapi.media_player.Attributes.STATE in update:
             new_state = self.state_from_media_player_state(update[ucapi.media_player.Attributes.STATE])
-            if new_state != self.attributes.get(Attributes.STATE):
+            if force or new_state != self.attributes.get(Attributes.STATE):
                 attributes[Attributes.STATE] = new_state
+        # TODO check for sensor value change
         if self.SENSOR_NAME in update:
             # make sure sensor-entity is available if data changes
             attributes[Attributes.STATE] = States.ON

--- a/intg-appletv/sensor.py
+++ b/intg-appletv/sensor.py
@@ -6,12 +6,14 @@ Sensor entity functions.
 """
 
 import logging
+from abc import abstractmethod
 from enum import Enum
 from typing import Any, Type
 
 import tv
 import ucapi.media_player
-from config import AppleTVEntity, AtvDevice, create_entity_id
+from config import AtvDevice, create_entity_id
+from entities import AppleTVEntity
 from ucapi import EntityTypes, IntegrationAPI, Sensor
 from ucapi.media_player import States as MediaStates
 from ucapi.sensor import Attributes, DeviceClasses, Options, States
@@ -74,9 +76,9 @@ class AppleTVSensor(Sensor, AppleTVEntity):
         return self._state
 
     @property
+    @abstractmethod
     def sensor_value(self) -> str:
         """Return sensor value."""
-        raise NotImplementedError()
 
     @property
     def all_attributes(self) -> dict[str, Any]:
@@ -89,17 +91,14 @@ class AppleTVSensor(Sensor, AppleTVEntity):
     def filter_changed_attributes(self, update: dict[str, Any]) -> dict[str, Any]:
         """Return only the changed attributes."""
         attributes: dict[str, Any] = {}
-        # TODO(#118) probably needs to be refactored
-        if update:
-            if ucapi.media_player.Attributes.STATE in update:
-                new_state = SENSOR_STATE_MAPPING.get(update[ucapi.media_player.Attributes.STATE], States.UNKNOWN)
-                if new_state != self._state:
-                    self._state = new_state
-                    attributes[Attributes.STATE] = self._state
-            if self.SENSOR_NAME in update:
-                attributes[Attributes.VALUE] = update[self.SENSOR_NAME]
-            return attributes
-        return self.all_attributes
+        if ucapi.media_player.Attributes.STATE in update:
+            new_state = SENSOR_STATE_MAPPING.get(update[ucapi.media_player.Attributes.STATE], States.UNKNOWN)
+            if new_state != self._state:
+                self._state = new_state
+                attributes[Attributes.STATE] = self._state
+        if self.SENSOR_NAME in update:
+            attributes[Attributes.VALUE] = update[self.SENSOR_NAME]
+        return attributes
 
 
 class AppSensor(AppleTVSensor):

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -13,6 +13,7 @@ import base64
 import datetime
 import hashlib
 import itertools
+import json
 import logging
 import random
 import re
@@ -840,7 +841,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             update.setdefault(AppleTVSelects.SELECT_AUDIO_OUTPUT, {})
             update[AppleTVSelects.SELECT_AUDIO_OUTPUT][SelectAttributes.CURRENT_OPTION] = self.output_devices
 
-        _LOG.debug("[%s] Updated sound mode list: %s", self.log_id, update)
+        _LOG.debug("[%s] Updated sound mode list: %s", self.log_id, json.dumps(update))
 
         if update:
             self.events.emit(EVENTS.UPDATE, self._device.identifier, update)

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -36,6 +36,7 @@ from typing import (
 import pyatv
 import pyatv.const
 from config import AtvDevice, AtvProtocol
+from entities import AppleTVSelects, AppleTVSensors
 from pyatv import interface
 from pyatv.const import (
     DeviceState,
@@ -66,7 +67,6 @@ from ucapi.media_player import Attributes as MediaAttr
 from ucapi.media_player import MediaContentType, RepeatMode
 from ucapi.media_player import States as MediaState
 from ucapi.select import Attributes as SelectAttributes
-from utils import AppleTVSelects, AppleTVSensors
 
 _LOG = logging.getLogger(__name__)
 

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -410,13 +410,13 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         """Play status push update callback handler (push_updater.listener)."""
         if _LOG.isEnabledFor(logging.DEBUG):
             _LOG.debug("[%s] Push update: %s", self.log_id, re.sub(r"\n\s*", ", ", str(playstatus)))
-        _ = asyncio.ensure_future(self._process_update(playstatus))
+        _ = asyncio.ensure_future(self._process_playing_update(playstatus))
 
     def playstatus_error(self, _updater, exception: Exception) -> None:
         """Play status push update error callback handler (push_updater.listener)."""
         _LOG.warning("[%s] A %s error occurred: %s", self.log_id, exception.__class__, exception)
         data = pyatv.interface.Playing()
-        _ = asyncio.ensure_future(self._process_update(data))
+        _ = asyncio.ensure_future(self._process_playing_update(data))
 
     def connection_lost(self, exception) -> None:
         """
@@ -753,7 +753,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             self._shuffle = data.shuffle != ShuffleState.Off
             update[MediaAttr.SHUFFLE] = self._shuffle
 
-    async def _process_update(self, data: pyatv.interface.Playing) -> None:  # pylint: disable=too-many-branches
+    async def _process_playing_update(self, data: pyatv.interface.Playing) -> None:
         # store current state: used in `media_state` property
         self._device_state = data.device_state
 
@@ -780,7 +780,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
                 update[AppleTVSelects.SELECT_APP] = {SelectAttributes.CURRENT_OPTION: self.app_name}
                 update[AppleTVSensors.SENSOR_APP] = self.app_name
 
-            self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
+        self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
 
     async def _update_app_list(self) -> None:
         _LOG.debug("[%s] Updating app list", self.log_id)

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -8,6 +8,8 @@ Uses the [pyatv](https://github.com/postlund/pyatv) library with concepts borrow
 :license: Mozilla Public License Version 2.0, see LICENSE for more details.
 """
 
+# pylint: disable=too-many-lines
+
 import asyncio
 import base64
 import datetime
@@ -75,9 +77,6 @@ BACKOFF_SEC = 2
 ARTWORK_WIDTH = 400
 ARTWORK_HEIGHT = 400
 ERROR_OS_WAIT = 0.5
-
-
-# pylint: disable=too-many-lines
 
 
 class EVENTS(StrEnum):

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -789,6 +789,10 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         try:
             update[MediaAttr.SOURCE_LIST] = []
             app_list = sorted(await self._atv.apps.app_list(), key=lambda item: item.name.lower())
+            if not app_list:
+                _LOG.info("[%s] No apps found, trying again later", self.log_id)
+                return
+            self._app_list.clear()
             for app in app_list:
                 self._app_list[app.name] = app.identifier
                 update[MediaAttr.SOURCE_LIST].append(app.name)
@@ -806,8 +810,6 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             atvs = await pyatv.scan(self._loop)
             if self._atv is None:
                 return
-            current_output_devices = self._available_output_devices
-            current_output_device = self.output_devices
             device_ids: list[str] = []
             self._available_output_devices = {}
             for atv in atvs:
@@ -823,23 +825,21 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             _LOG.warning("[%s] Output devices: protocol error", self.log_id)
             return
         update = {}
-        if set(current_output_devices.keys()) != set(self._available_output_devices.keys()) and len(device_ids) > 0:
-            # Build combinations of output devices. First device in the list is the current Apple TV
-            # When selecting this entry, it will disable all output devices
-            self._output_devices = OrderedDict()
-            self._output_devices[self._device.name] = []
-            self._build_output_devices_list(atvs, device_ids)
-            update[MediaAttr.SOUND_MODE_LIST] = self.output_devices_combinations
-            update[AppleTVSelects.SELECT_AUDIO_OUTPUT] = {
-                SelectAttributes.CURRENT_OPTION: self.output_devices,
-                SelectAttributes.OPTIONS: self.output_devices_combinations,
-            }
+        # Build combinations of output devices. The first device in the list is the current Apple TV.
+        # When selecting this entry, it will disable all output devices
+        self._output_devices = OrderedDict()
+        self._output_devices[self._device.name] = []
+        self._build_output_devices_list(atvs, device_ids)
+        update[MediaAttr.SOUND_MODE_LIST] = self.output_devices_combinations
+        update[AppleTVSelects.SELECT_AUDIO_OUTPUT] = {
+            SelectAttributes.CURRENT_OPTION: self.output_devices,
+            SelectAttributes.OPTIONS: self.output_devices_combinations,
+        }
 
-        if current_output_device != self.output_devices:
-            update[MediaAttr.SOUND_MODE] = self.output_devices
-            update[AppleTVSensors.SENSOR_AUDIO_OUTPUT] = self.output_devices
-            update.setdefault(AppleTVSelects.SELECT_AUDIO_OUTPUT, {})
-            update[AppleTVSelects.SELECT_AUDIO_OUTPUT][SelectAttributes.CURRENT_OPTION] = self.output_devices
+        update[MediaAttr.SOUND_MODE] = self.output_devices
+        update[AppleTVSensors.SENSOR_AUDIO_OUTPUT] = self.output_devices
+        update.setdefault(AppleTVSelects.SELECT_AUDIO_OUTPUT, {})
+        update[AppleTVSelects.SELECT_AUDIO_OUTPUT][SelectAttributes.CURRENT_OPTION] = self.output_devices
 
         _LOG.debug("[%s] Updated sound mode list: %s", self.log_id, json.dumps(update))
 
@@ -888,6 +888,11 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
 
             update[MediaAttr.STATE] = self.media_state
             self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
+
+            if len(self._app_list) == 0:
+                await self._update_app_list()
+            if not self._available_output_devices:
+                await self._update_output_devices()
 
             await asyncio.sleep(self._poll_interval)
         _LOG.debug("[%s] Polling task stopped", self.log_id)

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -385,7 +385,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             MediaAttr.SOUND_MODE: self.output_devices,
             MediaAttr.SHUFFLE: self._shuffle,
             MediaAttr.REPEAT: self._repeat,
-            # TODO when UC library udpated
+            # TODO when UC library updated
             # MediaAttr.MEDIA_ID : self._media_id,
             AppleTVSelects.SELECT_APP: {
                 SelectAttributes.CURRENT_OPTION: self.app_name,
@@ -885,8 +885,6 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             except Exception as ex:  # pylint: disable=broad-except
                 _LOG.error("[%s] Polling error: %s", self.log_id, ex)
 
-            # #117: Keep it simple: we can't reliably determine the old state.
-            #       The on_atv_update event receiver will filter out unchanged entity attributes
             update[MediaAttr.STATE] = self.media_state
             self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
 

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -172,7 +172,7 @@ def async_handle_atvlib_errors(
     async def wrapper(self: _AppleTvT, *args: _P.args, **kwargs: _P.kwargs) -> StatusCodes:
         # pylint: disable=protected-access
         if self._atv is None:
-            _LOG.debug("Command wrapper : not connected try reconnect")
+            _LOG.debug("[%s] Command wrapper: not connected try reconnect", self.log_id)
             await self.connect()
             if self._atv is None:
                 return StatusCodes.SERVICE_UNAVAILABLE
@@ -840,7 +840,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             update.setdefault(AppleTVSelects.SELECT_AUDIO_OUTPUT, {})
             update[AppleTVSelects.SELECT_AUDIO_OUTPUT][SelectAttributes.CURRENT_OPTION] = self.output_devices
 
-        _LOG.debug("Updated sound mode list : %s", update)
+        _LOG.debug("[%s] Updated sound mode list: %s", self.log_id, update)
 
         if update:
             self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
@@ -1295,7 +1295,10 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         device_entry = self._output_devices.get(device_name, None)
         if device_entry is None:
             _LOG.warning(
-                "Output device not found in the list %s (list : %s)", device_name, self.output_devices_combinations
+                "[%s] Output device not found in the list %s (list : %s)",
+                self.log_id,
+                device_name,
+                self.output_devices_combinations,
             )
             return StatusCodes.BAD_REQUEST
         output_devices = self._atv.audio.output_devices
@@ -1305,7 +1308,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         for device in output_devices:
             device_ids.append(device.identifier)
 
-        _LOG.debug("Removing output devices %s", device_ids)
+        _LOG.debug("[%s] Removing output devices: %s", self.log_id, device_ids)
         await self._atv.audio.remove_output_devices(*device_ids)
         if len(device_entry) == 0:
             return StatusCodes.OK
@@ -1318,7 +1321,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         if len(found_current_device) == 0:
             new_output_devices.append(self._atv.device_info.output_device_id)
 
-        _LOG.debug("Setting output devices %s", new_output_devices)
+        _LOG.debug("[%s] Setting output devices: %s", self.log_id, new_output_devices)
         await self._atv.audio.set_output_devices(*new_output_devices)
         return StatusCodes.OK
 

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -842,9 +842,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         update[AppleTVSelects.SELECT_AUDIO_OUTPUT][SelectAttributes.CURRENT_OPTION] = self.output_devices
 
         _LOG.debug("[%s] Updated sound mode list: %s", self.log_id, json.dumps(update))
-
-        if update:
-            self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
+        self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
 
     def _build_output_devices_list(self, atvs: list[BaseConfig], device_ids: list[str]):
         """Build possible combinations of output devices."""

--- a/intg-appletv/utils.py
+++ b/intg-appletv/utils.py
@@ -32,3 +32,17 @@ def filter_attributes(attributes, attribute_type: Type[Enum]) -> dict[str, Any]:
 def truncate_dict(data: dict[str, Any], max_len: int = 150) -> dict[str, Any]:
     """Return a copy of the dictionary with truncated values to given max length for logging."""
     return {k: (v[:max_len] + "..." if isinstance(v, str) and len(v) > max_len else v) for k, v in data.items()}
+
+
+def key_update_helper(key: str, value: str | list[Any] | None, attributes: dict, original_attributes: dict[str, Any]):
+    """Update the attribute dictionary with the given key and value."""
+    if value is None:
+        return attributes
+
+    if key in original_attributes:
+        if original_attributes[key] != value:
+            attributes[key] = value
+    else:
+        attributes[key] = value
+
+    return attributes

--- a/intg-appletv/utils.py
+++ b/intg-appletv/utils.py
@@ -5,22 +5,8 @@ Utility functions used for Apple TV integration.
 :license: Mozilla Public License Version 2.0, see LICENSE for more details.
 """
 
-from enum import Enum, StrEnum
+from enum import Enum
 from typing import Any, Type
-
-
-class AppleTVSelects(StrEnum):
-    """Apple TV select values."""
-
-    SELECT_APP = "select_app"
-    SELECT_AUDIO_OUTPUT = "select_audio_output"
-
-
-class AppleTVSensors(StrEnum):
-    """Apple TV sensor values."""
-
-    SENSOR_APP = "sensor_app"
-    SENSOR_AUDIO_OUTPUT = "sensor_audio_output"
 
 
 def filter_attributes(attributes, attribute_type: Type[Enum]) -> dict[str, Any]:

--- a/intg-appletv/utils.py
+++ b/intg-appletv/utils.py
@@ -21,7 +21,21 @@ def truncate_dict(data: dict[str, Any], max_len: int = 150) -> dict[str, Any]:
 
 
 def key_update_helper(key: str, value: str | list[Any] | None, attributes: dict, original_attributes: dict[str, Any]):
-    """Update the attribute dictionary with the given key and value."""
+    """
+    Update the given key in the ``attributes`` dictionary with the specified value if required.
+
+    The function compares the value of the key in the original attributes and updates it in
+    attributes only if it is different.
+
+    If the value is None, the original attributes dictionary is returned unmodified.
+
+    :param key: The key whose value needs to be updated.
+    :param value: The new value to associate with the key. It can be a string, list, or None.
+    :param attributes: The dictionary where the key-value pair might be updated.
+    :param original_attributes: The reference dictionary to check the current value of the key.
+    :return: The updated ``attributes`` dictionary.
+    :rtype: dict
+    """
     if value is None:
         return attributes
 


### PR DESCRIPTION
Implement entity-based attribute change filtering to avoid `entity_change` events for unchanged attributes.

This refactor simplifies attribute updates by moving the filtering logic from the driver/source level into the entity classes themselves. By allowing entities to track their own last known values, the integration now more accurately filters out redundant updates, following the pattern established in the Denon AVR integration.

#### Changes

- **Entity-Based Filtering Architecture**:
    - Moved most attribute filtering logic into entity classes via `filter_attributes`. Entities now track their own last known state to ensure events are only fired when values actually change.
    - Extracted `AppleTVEntity` base class to `intg-appletv/entities.py` to centralize shared logic and reduce circular dependencies.
    - Fixed issues where entity states could get out of sync by leveraging the `Entity` base class's state attribute instead of duplicate local tracking.
- **Driver & Device Logic Refinement**:
    - Converted `on_atv_update` to a synchronous function and streamlined how it dispatches updates to entities.
    - Improved app list and audio output retrieval in `tv.py`, ensuring updates are triggered if data is missing during polling.
    - Enhanced error handling with "fail hard" assertions in the driver to ensure expected entity classes are always present.
- **Stability & Bug Fixes**:
    - Fixed the `Playing` state update to ensure events are emitted whenever playback state changes, regardless of whether the app name changed.
    - Corrected the `cycle` parameter usage for selector next/previous commands.
    - Resolved a bug in power toggle logic by using an assumed state when `pyatv` reports an `Unknown` power state.
- **Code Quality & Utilities**:
    - Leveraged `@abstractmethod` in `Select` and `Sensor` base classes for better architectural enforcement.
    - Removed redundant `None` value handling in filtering methods across `selector.py` and `sensor.py`.
    - Centralized constants like `AppleTVSelects`, `AppleTVSensors`, and `AVAILABLE_ATTRIBUTES`.
    - Improved logging by adding missing device identifiers and logging complex structures (like sound mode lists) as JSON.
    - Introduced `key_update_helper` and `truncate_dict` in `utils.py` for cleaner attribute handling and debugging.

Closes #118