### PR TITLE
fix: audio output changes, simplify sensor and selector updates

### DIFF
--- a/intg-appletv/driver.py
+++ b/intg-appletv/driver.py
@@ -292,8 +292,8 @@ def on_device_removed(device: config.AtvDevice | None) -> None:
             _LOOP.create_task(atv.disconnect())
             atv.events.remove_all_listeners()
             for entity in _get_entities(atv.identifier, include_all=True):
-                api.configured_entities.remove(entity.id)
-                api.available_entities.remove(entity.id)
+                api.configured_entities.remove(entity.entity_id)
+                api.available_entities.remove(entity.entity_id)
 
 
 class JournaldFormatter(logging.Formatter):

--- a/intg-appletv/entities.py
+++ b/intg-appletv/entities.py
@@ -49,6 +49,11 @@ class AppleTVEntity(ABC):
     def atv_id(self) -> str:
         """Return the ATV device identifier."""
 
+    @property
+    def entity_id(self):
+        """Return the entity identifier."""
+        return self._entity_id
+
     @abstractmethod
     def state_from_media_player_state(self, state: media_player.States) -> Type[Enum]:
         """Map media-player state to target entity state."""

--- a/intg-appletv/media_player.py
+++ b/intg-appletv/media_player.py
@@ -143,7 +143,7 @@ class AppleTVMediaPlayer(MediaPlayer, AppleTVEntity):
             features.append(Features.SHUFFLE)
 
         attributes = filter_attributes(device.attributes, Attributes)
-        options = {Options.SIMPLE_COMMANDS: list(SimpleCommands)}
+        options: dict[str, list[Any]] = {Options.SIMPLE_COMMANDS: list(SimpleCommands)}
         super().__init__(
             entity_id, config_device.name, features, attributes, device_class=DeviceClasses.TV, options=options
         )

--- a/intg-appletv/selector.py
+++ b/intg-appletv/selector.py
@@ -12,8 +12,9 @@ from typing import Any, Awaitable, Callable, TypeAlias
 import tv
 import ucapi
 from config import AtvDevice, create_entity_id
-from entities import AppleTVEntity, AppleTVSelects
+from entities import AppleTVEntity
 from ucapi import EntityTypes, IntegrationAPI, Select, StatusCodes
+from ucapi.media_player import Attributes as MediaAttr
 from ucapi.media_player import States as MediaStates
 from ucapi.select import Attributes, Commands, States
 
@@ -45,7 +46,10 @@ class AppleTVSelect(Select, AppleTVEntity):
     """Representation of an Apple TV select entity."""
 
     ENTITY_NAME = "select"
-    SELECT_NAME: AppleTVSelects
+    _SELECT_CURRENT_ATTRIBUTE: str
+    """Update attribute name for current option."""
+    _SELECT_OPTIONS_ATTRIBUTE: str
+    """Update attribute name for select options."""
 
     def __init__(
         self,
@@ -88,7 +92,7 @@ class AppleTVSelect(Select, AppleTVEntity):
             Attributes.STATE: States.ON,
         }
 
-    def state_from_media_player_state(self, state: States) -> States:
+    def state_from_media_player_state(self, state: MediaStates) -> States:
         """Map media-player state to select state."""
         return _SELECTOR_STATE_MAPPING.get(state, States.UNKNOWN)
 
@@ -105,19 +109,15 @@ class AppleTVSelect(Select, AppleTVEntity):
             new_state = self.state_from_media_player_state(update[ucapi.media_player.Attributes.STATE])
             if force or new_state != self.attributes.get(Attributes.STATE):
                 attributes[Attributes.STATE] = new_state
-        # TODO untangle select-entity attribute updates.
-        if self.SELECT_NAME in update:
-            if Attributes.CURRENT_OPTION in update[self.SELECT_NAME]:
-                if force or update[self.SELECT_NAME][Attributes.CURRENT_OPTION] != self.attributes.get(
-                    Attributes.CURRENT_OPTION
-                ):
-                    attributes[Attributes.CURRENT_OPTION] = update[self.SELECT_NAME][Attributes.CURRENT_OPTION]
-            if Attributes.OPTIONS in update[self.SELECT_NAME]:
-                if force or update[self.SELECT_NAME][Attributes.OPTIONS] != self.attributes.get(Attributes.OPTIONS):
-                    attributes[Attributes.OPTIONS] = update[self.SELECT_NAME][Attributes.OPTIONS]
+        if self._SELECT_CURRENT_ATTRIBUTE in update:
+            if force or update[self._SELECT_CURRENT_ATTRIBUTE] != self.attributes.get(Attributes.CURRENT_OPTION):
+                attributes[Attributes.CURRENT_OPTION] = update[self._SELECT_CURRENT_ATTRIBUTE]
+        if self._SELECT_OPTIONS_ATTRIBUTE in update:
+            if force or update[self._SELECT_OPTIONS_ATTRIBUTE] != self.attributes.get(Attributes.OPTIONS):
+                attributes[Attributes.OPTIONS] = update[self._SELECT_OPTIONS_ATTRIBUTE]
         # make sure select-entity is available if data changes
         if attributes and Attributes.STATE not in update:
-            attributes[Attributes.STATE] = States.ON
+            attributes.setdefault(Attributes.STATE, States.ON)
         return attributes
 
     async def command(self, cmd_id: str, params: dict[str, Any] | None = None, *, websocket: Any) -> StatusCodes:
@@ -186,7 +186,8 @@ class AppSelect(AppleTVSelect):
     """Representation of an AppleTV selector entity."""
 
     ENTITY_NAME = "app"
-    SELECT_NAME = AppleTVSelects.SELECT_APP
+    _SELECT_CURRENT_ATTRIBUTE = MediaAttr.SOURCE.value
+    _SELECT_OPTIONS_ATTRIBUTE = MediaAttr.SOURCE_LIST.value
 
     def __init__(
         self,
@@ -222,7 +223,8 @@ class AudioOutputSelect(AppleTVSelect):
     """Audio output selector entity."""
 
     ENTITY_NAME = "audio_output"
-    SELECT_NAME = AppleTVSelects.SELECT_AUDIO_OUTPUT
+    _SELECT_CURRENT_ATTRIBUTE = MediaAttr.SOUND_MODE.value
+    _SELECT_OPTIONS_ATTRIBUTE = MediaAttr.SOUND_MODE_LIST.value
 
     def __init__(self, config_device: AtvDevice, device: tv.AppleTv, api: IntegrationAPI):
         """Initialize the class."""

--- a/intg-appletv/sensor.py
+++ b/intg-appletv/sensor.py
@@ -12,8 +12,9 @@ from typing import Any
 import tv
 import ucapi.media_player
 from config import AtvDevice, create_entity_id
-from entities import AppleTVEntity, AppleTVSensors
+from entities import AppleTVEntity
 from ucapi import EntityTypes, IntegrationAPI, Sensor
+from ucapi.media_player import Attributes as MediaAttr
 from ucapi.media_player import States as MediaStates
 from ucapi.sensor import Attributes, DeviceClasses, Options, States
 
@@ -34,7 +35,8 @@ class AppleTVSensor(Sensor, AppleTVEntity):
     """Representation of a AppleTV Sensor entity."""
 
     ENTITY_NAME = "sensor"
-    SENSOR_NAME: AppleTVSensors
+    _SENSOR_ATTRIBUTE: str
+    """Update attribute name for sensor value."""
 
     def __init__(
         self,
@@ -73,7 +75,7 @@ class AppleTVSensor(Sensor, AppleTVEntity):
             Attributes.STATE: _SENSOR_STATE_MAPPING.get(self._device.media_state),
         }
 
-    def state_from_media_player_state(self, state: States) -> States:
+    def state_from_media_player_state(self, state: MediaStates) -> States:
         """Map media-player state to sensor state."""
         return _SENSOR_STATE_MAPPING.get(state, States.UNKNOWN)
 
@@ -90,11 +92,11 @@ class AppleTVSensor(Sensor, AppleTVEntity):
             new_state = self.state_from_media_player_state(update[ucapi.media_player.Attributes.STATE])
             if force or new_state != self.attributes.get(Attributes.STATE):
                 attributes[Attributes.STATE] = new_state
-        if self.SENSOR_NAME in update:
-            if force or update[self.SENSOR_NAME] != self.attributes.get(Attributes.VALUE):
+        if self._SENSOR_ATTRIBUTE in update:
+            if force or update[self._SENSOR_ATTRIBUTE] != self.attributes.get(Attributes.VALUE):
                 # make sure sensor-entity is available if data changes
                 attributes.setdefault(Attributes.STATE, States.ON)
-                attributes[Attributes.VALUE] = update[self.SENSOR_NAME]
+                attributes[Attributes.VALUE] = update[self._SENSOR_ATTRIBUTE]
         return attributes
 
 
@@ -102,7 +104,7 @@ class AppSensor(AppleTVSensor):
     """Current App sensor entity."""
 
     ENTITY_NAME = "app"
-    SENSOR_NAME = AppleTVSensors.SENSOR_APP
+    _SENSOR_ATTRIBUTE = MediaAttr.SOURCE.value
 
     def __init__(
         self,
@@ -132,7 +134,7 @@ class AudioOutputSensor(AppleTVSensor):
     """Current audio output sensor entity."""
 
     ENTITY_NAME = "audio_output"
-    SENSOR_NAME = AppleTVSensors.SENSOR_AUDIO_OUTPUT
+    _SENSOR_ATTRIBUTE = MediaAttr.SOUND_MODE.value
 
     def __init__(
         self,

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -38,7 +38,6 @@ from typing import (
 import pyatv
 import pyatv.const
 from config import AtvDevice, AtvProtocol
-from entities import AppleTVSelects, AppleTVSensors
 from pyatv import interface
 from pyatv.const import (
     DeviceState,
@@ -68,7 +67,6 @@ from ucapi import StatusCodes
 from ucapi.media_player import Attributes as MediaAttr
 from ucapi.media_player import MediaContentType, RepeatMode
 from ucapi.media_player import States as MediaState
-from ucapi.select import Attributes as SelectAttributes
 
 _LOG = logging.getLogger(__name__)
 
@@ -390,16 +388,6 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             MediaAttr.REPEAT: self._repeat,
             # TODO when UC library updated
             # MediaAttr.MEDIA_ID : self._media_id,
-            AppleTVSelects.SELECT_APP: {
-                SelectAttributes.CURRENT_OPTION: self.app_name,
-                SelectAttributes.OPTIONS: self.app_names,
-            },
-            AppleTVSelects.SELECT_AUDIO_OUTPUT: {
-                SelectAttributes.CURRENT_OPTION: self.output_devices,
-                SelectAttributes.OPTIONS: self.output_devices_combinations,
-            },
-            AppleTVSensors.SENSOR_APP: self.app_name,
-            AppleTVSensors.SENSOR_AUDIO_OUTPUT: self.output_devices,
         }
 
     def _backoff(self) -> float:
@@ -779,8 +767,6 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             if source != self._source:
                 self._source = source
                 update[MediaAttr.SOURCE] = self._source
-                update[AppleTVSelects.SELECT_APP] = {SelectAttributes.CURRENT_OPTION: self.app_name}
-                update[AppleTVSensors.SENSOR_APP] = self.app_name
 
         self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
 
@@ -798,7 +784,6 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             for app in app_list:
                 self._app_list[app.name] = app.identifier
                 update[MediaAttr.SOURCE_LIST].append(app.name)
-            update[AppleTVSelects.SELECT_APP] = {SelectAttributes.OPTIONS: update[MediaAttr.SOURCE_LIST]}
         except pyatv.exceptions.NotSupportedError:
             _LOG.warning("[%s] App list is not supported", self.log_id)
         except pyatv.exceptions.ProtocolError:
@@ -827,22 +812,14 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         except pyatv.exceptions.ProtocolError:
             _LOG.warning("[%s] Output devices: protocol error", self.log_id)
             return
-        update = {}
+        update: dict[str, Any] = {}
         # Build combinations of output devices. The first device in the list is the current Apple TV.
         # When selecting this entry, it will disable all output devices
         self._output_devices = OrderedDict()
         self._output_devices[self._device.name] = frozenset()
         self._build_output_devices_list(id_to_name, device_ids)
         update[MediaAttr.SOUND_MODE_LIST] = self.output_devices_combinations
-        update[AppleTVSelects.SELECT_AUDIO_OUTPUT] = {
-            SelectAttributes.CURRENT_OPTION: self.output_devices,
-            SelectAttributes.OPTIONS: self.output_devices_combinations,
-        }
-
         update[MediaAttr.SOUND_MODE] = self.output_devices
-        update[AppleTVSensors.SENSOR_AUDIO_OUTPUT] = self.output_devices
-        update.setdefault(AppleTVSelects.SELECT_AUDIO_OUTPUT, {})
-        update[AppleTVSelects.SELECT_AUDIO_OUTPUT][SelectAttributes.CURRENT_OPTION] = self.output_devices
 
         _LOG.debug("[%s] Updated sound mode list: %s", self.log_id, json.dumps(update))
         self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
@@ -883,8 +860,6 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             app_name = self.app_name
             if app_name:
                 update[MediaAttr.SOURCE] = app_name
-                update[AppleTVSelects.SELECT_APP] = {SelectAttributes.CURRENT_OPTION: app_name}
-                update[AppleTVSensors.SENSOR_APP] = app_name
 
             try:
                 if data := await self._atv.metadata.playing():
@@ -1385,10 +1360,6 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         attributes[MediaAttr.REPEAT] = RepeatMode.OFF
         attributes[MediaAttr.SHUFFLE] = False
         attributes[MediaAttr.SOURCE] = ""
-        attributes[AppleTVSelects.SELECT_APP] = {
-            SelectAttributes.CURRENT_OPTION: "",
-        }
-        attributes[AppleTVSensors.SENSOR_APP] = ""
         self._media_position = None
         self._media_duration = None
         self._media_image_url = None


### PR DESCRIPTION
Use media-player update attributes for select- and sensor-entities. This removes complexity and duplications.

- Replace `AppleTVSensors` and `AppleTVSelects` constants with media player attributes.
- Simplify attribute handling by leveraging `_SELECT` and `_SENSOR` attribute mappings.
- Cleanup redundant sensor and selector update logic.

These changes also fix the update of changed audio outputs in the select- and sensor-entities.