### PR TITLE
fix: handle pyatv deadlock exceptions

### DIFF
--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -176,10 +176,7 @@ def async_handle_atvlib_errors(
         except (pyatv.exceptions.ConnectionFailedError, pyatv.exceptions.ConnectionLostError) as err:
             result = StatusCodes.SERVICE_UNAVAILABLE
             _LOG.warning("[%s] ATV network error (%s%s): %s", self.log_id, func.__name__, args, err)
-            # Prevent duplicate DISCONNECTED events if the underlying connection_lost/connection_closed callback already
-            # ran and cleared self._atv
-            if self._atv is not None:  # pyright: ignore[reportPrivateUsage, reportUnnecessaryComparison]
-                self._handle_disconnect()  # pyright: ignore[reportPrivateUsage]
+            self._handle_disconnect()  # pyright: ignore[reportPrivateUsage]
         except pyatv.exceptions.AuthenticationError as err:
             result = StatusCodes.UNAUTHORIZED
             _LOG.warning("[%s] Authentication error (%s%s): %s", self.log_id, func.__name__, args, err)
@@ -202,7 +199,7 @@ def async_handle_atvlib_errors(
             result = StatusCodes.SERVICE_UNAVAILABLE
             _LOG.error("[%s] Command is blocked (%s%s), reconnecting...", self.log_id, func.__name__, args)
             self._handle_disconnect()  # pyright: ignore[reportPrivateUsage]
-        except Exception as err:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        except Exception as err:  # noqa: BLE001
             _LOG.exception("[%s] Error %s occurred in method %s%s", self.log_id, err, func.__name__, args)
 
         return result
@@ -369,7 +366,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             app = self._atv.metadata.app
             if app and app.name:
                 app_name = app.name
-        except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             # Most common exception is pyatv.exceptions.NotSupportedError, but there might be others
             _LOG.exception("[%s] Error getting app name", self.log_id)
         return app_name or ""
@@ -430,7 +427,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         This is a callback function from pyatv.interface.DeviceListener.
         """
         _LOG.warning("[%s] Lost connection: %s", self.log_id, exception)
-        self._handle_disconnect()
+        self._handle_disconnect(force=True)
 
     @override
     def connection_closed(self) -> None:
@@ -439,14 +436,21 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         This is a callback function from pyatv.interface.DeviceListener.
         """
         _LOG.debug("[%s] Connection closed!", self.log_id)
-        self._handle_disconnect()
+        self._handle_disconnect(force=True)
 
-    def _handle_disconnect(self) -> None:
+    def _handle_disconnect(self, *, force: bool = False) -> None:
         """Handle that the device disconnected and restart the connection loop."""
+        if not force and self._atv is None:
+            return
+
         self._spawn_task(self._stop_polling())
-        if self._atv:
-            self._atv.close()
-            self._atv = None
+
+        # detach atv to prevent recursion with sync `connection_closed` callback in atv.close()
+        atv = self._atv
+        self._atv = None
+        if atv:
+            atv.close()
+
         # make sure the DISCONNECTED listener is sync to avoid any race conditions!
         self.events.emit(EVENTS.DISCONNECTED, self._device.identifier)
         self._start_connect_loop()
@@ -627,9 +631,9 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             await self._start_polling()
 
             if self._atv.features.in_state(FeatureState.Available, FeatureName.AppList):
-                self._loop.create_task(self._update_app_list())
+                self._spawn_task(self._update_app_list())
 
-            self._loop.create_task(self._update_output_devices())
+            self._spawn_task(self._update_output_devices())
 
             self.events.emit(EVENTS.CONNECTED, self._device.identifier)
             _LOG.debug("[%s] Connected", self.log_id)
@@ -644,8 +648,10 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
                 err.args[0] if err.args else "blocked",
                 err,
             )
-            if self._atv is not None:  # pyright: ignore[reportUnnecessaryComparison]
-                self._handle_disconnect()
+            self._handle_disconnect()
+        except Exception as err:  # noqa: BLE001
+            _LOG.exception("[%s] Error during post-connect setup, reconnecting: %s", self.log_id, err)
+            self._handle_disconnect(force=True)
 
     async def _connect_once(self) -> bool:
         try:
@@ -661,7 +667,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             return False
         except asyncio.CancelledError:
             return False
-        except Exception as err:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        except Exception as err:  # noqa: BLE001
             _LOG.warning("[%s] Could not connect: %s", self.log_id, err)
             # OSError(101, 'Network is unreachable') or 10065 for Windows
             if err.__cause__ and isinstance(err.__cause__, OSError) and err.__cause__.errno in [101, 10065]:
@@ -673,7 +679,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
                     if self._apple_tv_conf:
                         await self._connect(self._apple_tv_conf)
                         return self._atv is not None
-                except Exception as err2:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+                except Exception as err2:  # noqa: BLE001
                     _LOG.warning("[%s] Could not connect: %s", self.log_id, err2)
                     self._atv = None
             else:
@@ -729,7 +735,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
                 self._atv.close()
             if self._connect_task:
                 self._connect_task.cancel()
-        except Exception as err:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        except Exception as err:  # noqa: BLE001
             _LOG.exception("[%s] An error occurred while disconnecting: %s", self.log_id, err)
         finally:
             self._atv = None
@@ -949,18 +955,16 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             except pyatv.exceptions.BlockedStateError as ex:
                 # The pyatv facade was closed under us; trigger a clean reconnect and exit.
                 _LOG.warning("[%s] Polling: connection blocked, triggering reconnect: %s", self.log_id, ex)
-                if self._atv is not None:  # pyright: ignore[reportUnnecessaryComparison]
-                    self._handle_disconnect()
+                self._handle_disconnect()
                 return
             except (pyatv.exceptions.ConnectionFailedError, pyatv.exceptions.ConnectionLostError) as ex:
                 # Connection was lost during a poll; let _handle_disconnect restart the loop.
                 _LOG.warning("[%s] Polling: connection lost, triggering reconnect: %s", self.log_id, ex)
-                if self._atv is not None:  # pyright: ignore[reportUnnecessaryComparison]
-                    self._handle_disconnect()
+                self._handle_disconnect()
                 return
             except pyatv.exceptions.NotSupportedError:
                 pass
-            except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
+            except Exception as ex:  # noqa: BLE001
                 _LOG.error("[%s] Polling error: %s", self.log_id, ex)
 
             update[MediaAttr.STATE] = self.media_state
@@ -1020,7 +1024,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
                     if self._media_image_url != current_media_image_url:
                         update[MediaAttr.MEDIA_IMAGE_URL] = self._media_image_url
                     ARTWORK_CACHE[self._device.identifier] = artwork_hash
-            except Exception as err:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+            except Exception as err:  # noqa: BLE001
                 _LOG.warning("[%s] Error while updating the artwork: %s", self.log_id, err)
         else:
             # Not playing - clear caches so that artwork is sent again when playback starts
@@ -1051,7 +1055,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
                     api = getattr(main_instance, "api", None)
                     if isinstance(api, CompanionAPI):
                         return await api.fetch_attention_state()
-        except Exception as ex:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        except Exception as ex:  # noqa: BLE001
             _LOG.debug("[%s] Failed to fetch system status: %s", self.log_id, ex)
         return SystemStatus.Unknown
 

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -176,6 +176,7 @@ def async_handle_atvlib_errors(
         except (pyatv.exceptions.ConnectionFailedError, pyatv.exceptions.ConnectionLostError) as err:
             result = StatusCodes.SERVICE_UNAVAILABLE
             _LOG.warning("[%s] ATV network error (%s%s): %s", self.log_id, func.__name__, args, err)
+            self._handle_disconnect()  # pyright: ignore[reportPrivateUsage]
         except pyatv.exceptions.AuthenticationError as err:
             result = StatusCodes.UNAUTHORIZED
             _LOG.warning("[%s] Authentication error (%s%s): %s", self.log_id, func.__name__, args, err)
@@ -606,24 +607,41 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             _LOG.error("[%s] Connection loop ended without successful connection", self.log_id)
             return
 
-        # Add callback listener for various push updates
-        self._atv.push_updater.listener = self
-        self._atv.push_updater.start()
-        self._atv.listener = self
-        self._atv.audio.listener = self
+        # Set up listeners and start push updates.
+        # pyatv blocks the facade immediately after close(), so any access here can raise
+        # BlockedStateError if the connection was lost between _connect_once() returning and
+        # this point.  We set self._atv.listener = self FIRST so that from this point forward
+        # connection_lost/connection_closed callbacks will fire even if we crash mid-setup.
+        try:
+            self._atv.listener = self
+            self._atv.push_updater.listener = self
+            self._atv.push_updater.start()
+            self._atv.audio.listener = self
 
-        # Reset the backoff counter
-        self._connection_attempts = 0
+            # Reset the backoff counter
+            self._connection_attempts = 0
 
-        await self._start_polling()
+            await self._start_polling()
 
-        if self._atv.features.in_state(FeatureState.Available, FeatureName.AppList):
-            self._loop.create_task(self._update_app_list())
+            if self._atv.features.in_state(FeatureState.Available, FeatureName.AppList):
+                self._loop.create_task(self._update_app_list())
 
-        self._loop.create_task(self._update_output_devices())
+            self._loop.create_task(self._update_output_devices())
 
-        self.events.emit(EVENTS.CONNECTED, self._device.identifier)
-        _LOG.debug("[%s] Connected", self.log_id)
+            self.events.emit(EVENTS.CONNECTED, self._device.identifier)
+            _LOG.debug("[%s] Connected", self.log_id)
+        except pyatv.exceptions.BlockedStateError as err:
+            # The pyatv facade was already closed/blocked before we could finish setup.
+            # This happens when the remote side drops the connection in the narrow window
+            # after pyatv.connect() returns but before our listener is fully wired up.
+            # Trigger a clean disconnect so the reconnect loop restarts.
+            _LOG.warning(
+                "[%s] Connection was lost during post-connect setup (%s): %s",
+                self.log_id,
+                err.args[0] if err.args else "blocked",
+                err,
+            )
+            self._handle_disconnect()
 
     async def _connect_once(self) -> bool:
         try:
@@ -834,6 +852,10 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             _LOG.warning("[%s] App list is not supported", self.log_id)
         except pyatv.exceptions.ProtocolError:
             _LOG.warning("[%s] App list: protocol error", self.log_id)
+        except pyatv.exceptions.BlockedStateError:
+            # Connection was closed while we were fetching the app list; ignore silently.
+            _LOG.debug("[%s] Connection closed during app list update, skipping", self.log_id)
+            return
 
         self.events.emit(EVENTS.UPDATE, self._device.identifier, update)
 
@@ -857,6 +879,10 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             return
         except pyatv.exceptions.ProtocolError:
             _LOG.warning("[%s] Output devices: protocol error", self.log_id)
+            return
+        except pyatv.exceptions.BlockedStateError:
+            # Connection was closed while we were fetching output devices; ignore silently.
+            _LOG.debug("[%s] Connection closed during output device update, skipping", self.log_id)
             return
         update: dict[str, Any] = {}
         # Build combinations of output devices. The first device in the list is the current Apple TV.
@@ -916,6 +942,16 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
                 else:
                     # No playback data available, clear the artwork
                     await self._process_artwork(update, None)
+            except pyatv.exceptions.BlockedStateError as ex:
+                # The pyatv facade was closed under us; trigger a clean reconnect and exit.
+                _LOG.warning("[%s] Polling: connection blocked, triggering reconnect: %s", self.log_id, ex)
+                self._handle_disconnect()
+                return
+            except (pyatv.exceptions.ConnectionFailedError, pyatv.exceptions.ConnectionLostError) as ex:
+                # Connection was lost during a poll; let _handle_disconnect restart the loop.
+                _LOG.warning("[%s] Polling: connection lost, triggering reconnect: %s", self.log_id, ex)
+                self._handle_disconnect()
+                return
             except pyatv.exceptions.NotSupportedError:
                 pass
             except Exception as ex:  # pylint: disable=broad-except  # noqa: BLE001
@@ -991,7 +1027,10 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
 
     def _is_feature_available(self, feature: FeatureName) -> bool:
         if self._atv:
-            return self._atv.features.in_state(FeatureState.Available, feature)
+            try:
+                return self._atv.features.in_state(FeatureState.Available, feature)
+            except pyatv.exceptions.BlockedStateError:
+                return False
         return False
 
     async def _system_status(self) -> SystemStatus:

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -176,7 +176,10 @@ def async_handle_atvlib_errors(
         except (pyatv.exceptions.ConnectionFailedError, pyatv.exceptions.ConnectionLostError) as err:
             result = StatusCodes.SERVICE_UNAVAILABLE
             _LOG.warning("[%s] ATV network error (%s%s): %s", self.log_id, func.__name__, args, err)
-            self._handle_disconnect()  # pyright: ignore[reportPrivateUsage]
+            # Prevent duplicate DISCONNECTED events if the underlying connection_lost/connection_closed callback already
+            # ran and cleared self._atv
+            if self._atv is not None:  # pyright: ignore[reportPrivateUsage, reportUnnecessaryComparison]
+                self._handle_disconnect()  # pyright: ignore[reportPrivateUsage]
         except pyatv.exceptions.AuthenticationError as err:
             result = StatusCodes.UNAUTHORIZED
             _LOG.warning("[%s] Authentication error (%s%s): %s", self.log_id, func.__name__, args, err)
@@ -641,7 +644,8 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
                 err.args[0] if err.args else "blocked",
                 err,
             )
-            self._handle_disconnect()
+            if self._atv is not None:  # pyright: ignore[reportUnnecessaryComparison]
+                self._handle_disconnect()
 
     async def _connect_once(self) -> bool:
         try:
@@ -945,12 +949,14 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             except pyatv.exceptions.BlockedStateError as ex:
                 # The pyatv facade was closed under us; trigger a clean reconnect and exit.
                 _LOG.warning("[%s] Polling: connection blocked, triggering reconnect: %s", self.log_id, ex)
-                self._handle_disconnect()
+                if self._atv is not None:  # pyright: ignore[reportUnnecessaryComparison]
+                    self._handle_disconnect()
                 return
             except (pyatv.exceptions.ConnectionFailedError, pyatv.exceptions.ConnectionLostError) as ex:
                 # Connection was lost during a poll; let _handle_disconnect restart the loop.
                 _LOG.warning("[%s] Polling: connection lost, triggering reconnect: %s", self.log_id, ex)
-                self._handle_disconnect()
+                if self._atv is not None:  # pyright: ignore[reportUnnecessaryComparison]
+                    self._handle_disconnect()
                 return
             except pyatv.exceptions.NotSupportedError:
                 pass


### PR DESCRIPTION
This PR improves the Apple TV connection lifecycle to recover from cases where `pyatv` closes or blocks the facade while the integration is still completing setup or polling. This addresses a deadlock scenario where the connect loop could terminate after a `BlockedStateError` and never reconnect to the Apple TV device.

### Key Changes

- Added safer disconnect handling in `AppleTv._handle_disconnect`.
  - Supports forced disconnect handling for callbacks from `pyatv`.
  - Detaches the current ATV instance before calling `close()` to avoid recursive `connection_closed` handling.
  - Stops polling, emits the disconnect event, and restarts the connect loop when appropriate.

- Updated `connection_lost` and `connection_closed` callbacks to force reconnect handling.
  - Ensures reconnect logic runs even if `pyatv` already considers the facade closed or blocked.

- Hardened post-connect setup against `BlockedStateError`.
  - Listener setup, push updater startup, audio listener setup, polling startup, and initial metadata updates are now wrapped.
  - If `pyatv` raises `BlockedStateError` during setup, the integration logs the issue and triggers reconnect handling instead of letting the connect task die.

- Added fallback handling for unexpected post-connect setup errors.
  - Prevents the connection loop from silently ending if another exception occurs while finalizing the connection.

- Improved background task handling.
  - Added a helper to track fire-and-forget tasks and log unhandled exceptions.
  - Push updates, app list refreshes, and output device refreshes now use tracked background tasks to avoid “Task exception was never retrieved” errors.

- Improved blocked/disconnected polling behavior.
  - Polling now catches `BlockedStateError`, `ConnectionFailedError`, and `ConnectionLostError`.
  - These errors trigger clean reconnect handling instead of leaving polling or connection state stuck.

- Added guards around app list and output device updates.
  - `BlockedStateError` during these asynchronous refreshes is handled gracefully and logged at debug level.