### PR TITLE
refactor: drive connection lifecycle from sans-I/O state machine (spec 001, phase 3)

### DIFF
--- a/docs/specs/001-connection-lifecycle-state-machine.md
+++ b/docs/specs/001-connection-lifecycle-state-machine.md
@@ -2,7 +2,7 @@
 
 |                         |                                                                                                                                                                |
 |-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Status**              | Approved (2026-07-16) — Phases 1–2 implemented; Phases 3–4 pending                                                                                              |
+| **Status**              | Approved (2026-07-16) — Phases 1–3 implemented; Phase 4 pending                                                                                                 |
 | **Author**              | Claude (Opus 4.8), commissioned by Markus Zehnder                                                                                                              |
 | **Date**                | 2026-07-16                                                                                                                                                     |
 | **Reviewed**            | 2026-07-16 — verified against sources (`main` @ `4f838f1`); gaps corrected in place (poll-worker call sites, supervisor termination, conf-cache semantics, adoption bootstrap, `wait_for_state` contract, INV-6/AC-6 wording) |

--- a/intg-appletv/tv.py
+++ b/intg-appletv/tv.py
@@ -13,6 +13,7 @@ from asyncio import AbstractEventLoop, Task
 import base64
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Coroutine
+from contextlib import suppress
 import datetime
 from enum import Enum, StrEnum
 from functools import wraps
@@ -51,12 +52,11 @@ from ucapi import StatusCodes
 from ucapi.media_player import Attributes as MediaAttr, MediaContentType, RepeatMode, States as MediaState
 
 from config import AtvDevice, AtvProtocol
+from connection_machine import Action, ConnectionMachine, ConnectionState, Event
 from utils import replace_bad_chars
 
 _LOG = logging.getLogger(__name__)
 
-BACKOFF_MAX = 30
-BACKOFF_SEC = 2
 ARTWORK_WIDTH = 400
 ARTWORK_HEIGHT = 400
 ERROR_OS_WAIT = 0.5
@@ -65,13 +65,13 @@ CONNECT_TIMEOUT = 15.0
 APP_LIST_REFRESH_INTERVAL = 300.0
 OUTPUT_REFRESH_INTERVAL = 300.0
 CONNECT_WAIT_FOR_COMMAND = 3.0
+STOP_TIMEOUT = 5.0
+"""Maximum time in seconds disconnect() waits for the state machine to reach STOPPED."""
 
 
 class EVENTS(StrEnum):
     """Internal driver events."""
 
-    CONNECTING = "CONNECTING"  # TODO emitted, but no handler
-    """Device connecting event. Parameter: device identifier."""
     CONNECTED = "CONNECTED"
     """Device connected event. Parameter: device identifier."""
     DISCONNECTED = "DISCONNECTED"
@@ -171,17 +171,7 @@ def async_handle_atvlib_errors(
             _LOG.debug("[%s] Command wrapper: not connected, requesting reconnect", self.log_id)
             await self.connect()
             # Give an in-flight connection a brief moment so a command right after wake can land.
-            try:
-                async with asyncio.timeout(CONNECT_WAIT_FOR_COMMAND):
-                    # Deliberate bounded polling: the connect loop has no completion event to wait on.
-                    while (  # noqa: ASYNC110
-                        self._atv is None  # pyright: ignore[reportPrivateUsage]
-                        and self._is_enabled  # pyright: ignore[reportPrivateUsage]
-                        and not self._auth_failed  # pyright: ignore[reportPrivateUsage]
-                    ):
-                        await asyncio.sleep(0.1)
-            except TimeoutError:
-                pass
+            await self.wait_for_state({ConnectionState.CONNECTED}, timeout_s=CONNECT_WAIT_FOR_COMMAND)
             if self._atv is None:  # pyright: ignore[reportPrivateUsage]
                 return StatusCodes.SERVICE_UNAVAILABLE
 
@@ -200,7 +190,7 @@ def async_handle_atvlib_errors(
         except (pyatv.exceptions.ConnectionFailedError, pyatv.exceptions.ConnectionLostError) as err:
             result = StatusCodes.SERVICE_UNAVAILABLE
             _LOG.warning("[%s] ATV network error (%s%s): %s", self.log_id, func.__name__, args, err)
-            self._handle_disconnect()  # pyright: ignore[reportPrivateUsage]
+            self._post(Event.CONNECTION_LOST)  # pyright: ignore[reportPrivateUsage]
         except pyatv.exceptions.AuthenticationError as err:
             result = StatusCodes.UNAUTHORIZED
             _LOG.warning("[%s] Authentication error (%s%s): %s", self.log_id, func.__name__, args, err)
@@ -222,7 +212,7 @@ def async_handle_atvlib_errors(
         except pyatv.exceptions.BlockedStateError:
             result = StatusCodes.SERVICE_UNAVAILABLE
             _LOG.error("[%s] Command is blocked (%s%s), reconnecting...", self.log_id, func.__name__, args)
-            self._handle_disconnect()  # pyright: ignore[reportPrivateUsage]
+            self._post(Event.CONNECTION_LOST)  # pyright: ignore[reportPrivateUsage]
         except Exception as err:  # noqa: BLE001
             _LOG.exception("[%s] Error %s occurred in method %s%s", self.log_id, err, func.__name__, args)
 
@@ -233,6 +223,10 @@ def async_handle_atvlib_errors(
 
 ARTWORK_CACHE: dict[str, bytes] = {}
 PLAYING_STATE_CACHE: dict[str, int] = {}
+
+
+class _AdoptFailed(Exception):
+    """Adoption of a freshly connected handle failed; the supervisor triggers a reconnect (F4)."""
 
 
 class AppleTv(interface.AudioListener, interface.DeviceListener):
@@ -247,16 +241,20 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         """Create instance."""
         self._loop: AbstractEventLoop = loop or asyncio.get_running_loop()
         self.events = AsyncIOEventEmitter(self._loop)
-        self._is_enabled: bool = False
-        """Determine if the ATV connection should be kept alive."""
-        self._auth_failed: bool = False
-        """Set when connecting fails with an authentication error; stops reconnect attempts until re-paired."""
+        self._machine = ConnectionMachine()
+        """Pure connection lifecycle state machine; owns the connection state (INV-2)."""
+        self._event_queue: asyncio.Queue[tuple[Event, pyatv.interface.AppleTV | None]] = asyncio.Queue()
+        """Single FIFO queue serializing all lifecycle events; payload only for CONNECT_SUCCEEDED (INV-4)."""
+        self._supervisor: Task[None] | None = None
+        """Single consumer of the event queue; the only writer of `_atv` (INV-3, INV-9)."""
+        self._state_changed: asyncio.Event = asyncio.Event()
+        """Pulsed by the supervisor after every applied transition; used by `wait_for_state`."""
+        self._retry_task: Task[None] | None = None
         self._atv: pyatv.interface.AppleTV | None = None
         if not device.credentials:
             device.credentials = []
         self._device: AtvDevice = device
         self._connect_task: Task[Any] | None = None
-        self._connection_attempts: int = 0
         self._pairing_atv: pyatv.interface.BaseConfig | None = pairing_atv
         self._pairing_process: pyatv.interface.PairingHandler | None = None
         self._polling: Task[Any] | None = None
@@ -337,8 +335,13 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
 
     @property
     def is_enabled(self) -> bool:
-        """Return whether the device is enabled."""
-        return self._is_enabled
+        """Return whether the device connection should be kept alive (derived from the state machine)."""
+        return self._machine.state is not ConnectionState.STOPPED
+
+    @property
+    def state(self) -> ConnectionState:
+        """Return the current connection lifecycle state."""
+        return self._machine.state
 
     @property
     def media_state(self) -> MediaState:
@@ -430,12 +433,6 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             # MediaAttr.MEDIA_ID : self._media_id,
         }
 
-    def _backoff(self) -> float:
-        if self._connection_attempts * BACKOFF_SEC >= BACKOFF_MAX:
-            return BACKOFF_MAX
-
-        return self._connection_attempts * BACKOFF_SEC
-
     def playstatus_update(self, _updater: Any, playstatus: pyatv.interface.Playing) -> None:
         """Play status push update callback handler (push_updater.listener)."""
         if _LOG.isEnabledFor(logging.DEBUG):
@@ -454,35 +451,20 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         Device was unexpectedly disconnected.
 
         This is a callback function from pyatv.interface.DeviceListener.
+        It must never block or run teardown inline (INV-7).
         """
         _LOG.warning("[%s] Lost connection: %s", self.log_id, exception)
-        self._handle_disconnect(force=True)
+        self._post(Event.CONNECTION_LOST)
 
     @override
     def connection_closed(self) -> None:
         """Device connection was closed.
 
         This is a callback function from pyatv.interface.DeviceListener.
+        It must never block or run teardown inline (INV-7).
         """
         _LOG.debug("[%s] Connection closed!", self.log_id)
-        self._handle_disconnect(force=True)
-
-    def _handle_disconnect(self, *, force: bool = False) -> None:
-        """Handle that the device disconnected and restart the connection loop."""
-        if not force and self._atv is None:
-            return
-
-        self._spawn_task(self._stop_polling())
-
-        # detach atv to prevent recursion with sync `connection_closed` callback in atv.close()
-        atv = self._atv
-        self._atv = None
-        if atv:
-            atv.close()
-
-        # make sure the DISCONNECTED listener is sync to avoid any race conditions!
-        self.events.emit(EVENTS.DISCONNECTED, self._device.identifier)
-        self._start_connect_loop()
+        self._post(Event.CONNECTION_LOST)
 
     def _volume_notify(self) -> None:
         """Calculate the average volume level of all connected devices."""
@@ -614,55 +596,120 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
         self._pairing_process = None
         return res
 
+    def _post(self, event: Event, payload: pyatv.interface.AppleTV | None = None) -> None:
+        """Enqueue a lifecycle event for the supervisor (safe from sync pyatv callbacks, INV-4/INV-7)."""
+        self._event_queue.put_nowait((event, payload))
+
     async def connect(self) -> None:
-        """Ensure the device is being supervised/connected (idempotent)."""
-        self._is_enabled = True
-        self._auth_failed = False  # a reconfigure/re-pair should retry after an auth failure
-        self._start_connect_loop()
+        """Ensure the device is being supervised and connecting (idempotent)."""
+        if self._supervisor is None or self._supervisor.done():
+            self._supervisor = self._loop.create_task(self._run_supervisor())
+        self._post(Event.START)
 
-    def _start_connect_loop(self) -> None:
-        if not self._connect_task and self._atv is None and self._is_enabled:
-            self.events.emit(EVENTS.CONNECTING, self._device.identifier)
-            self._connect_task = asyncio.create_task(self._connect_loop())
-        else:
-            _LOG.debug(
-                "[%s] Not starting connect loop (ATV: %s, enabled: %s)",
-                self.log_id,
-                self._atv is None,
-                self._is_enabled,
-            )
-
-    async def _connect_loop(self) -> None:
-        _LOG.debug("[%s] Starting connect loop", self.log_id)
-        while self._is_enabled and self._atv is None and not self._auth_failed:
-            if await self._connect_once():
-                break
-            self._connection_attempts += 1
-            backoff = self._backoff()
-            _LOG.debug("[%s] Trying to connect again in %ds", self.log_id, backoff)
-            await asyncio.sleep(backoff)
-
-        _LOG.debug("[%s] Connect loop ended", self.log_id)
-        self._connect_task = None
-
-        # Safety check for future refactoring and to satisfy linter
-        if not self._atv:
-            _LOG.error("[%s] Connection loop ended without successful connection", self.log_id)
+    async def disconnect(self) -> None:
+        """Disconnect from ATV and stop supervising it; returns once the state machine reached STOPPED."""
+        _LOG.debug("[%s] Disconnecting from device", self.log_id)
+        if self._supervisor is None or self._supervisor.done():
+            # Never supervised (e.g. pairing-only instance in the setup flow): nothing to stop.
             return
+        self._post(Event.STOP)
+        if not await self.wait_for_state({ConnectionState.STOPPED}, timeout_s=STOP_TIMEOUT):
+            _LOG.warning("[%s] Timeout waiting for STOPPED state while disconnecting", self.log_id)
+        await self._stop_supervisor()
 
-        # Set up listeners and start push updates.
-        # pyatv blocks the facade immediately after close(), so any access here can raise
-        # BlockedStateError if the connection was lost between _connect_once() returning and
-        # this point.  We set self._atv.listener = self FIRST so that from this point forward
-        # connection_lost/connection_closed callbacks will fire even if we crash mid-setup.
+    async def wait_for_state(self, targets: set[ConnectionState], timeout_s: float) -> bool:
+        """
+        Wait until the state machine reaches one of the target states.
+
+        Returns immediately when already in a target state. Returns ``False`` on timeout
+        instead of raising, so callers never leak a ``TimeoutError``.
+        """
+        if self._machine.state in targets:
+            return True
         try:
-            self._atv.listener = self
-            self._atv.push_updater.listener = self
-            self._atv.push_updater.start()
-            self._atv.audio.listener = self
+            async with asyncio.timeout(timeout_s):
+                while self._machine.state not in targets:
+                    await self._state_changed.wait()
+        except TimeoutError:
+            return False
+        return True
 
-            # Reset the backoff counter
-            self._connection_attempts = 0
+    async def _run_supervisor(self) -> None:
+        """Drain the event queue and apply the machine's actions — the single owner of `_atv` (INV-3/INV-9)."""
+        while True:
+            event, payload = await self._event_queue.get()
+            state_before = self._machine.state
+            actions = self._machine.handle(event)
+            _LOG.debug(
+                "[%s] %s: %s -> %s %s", self.log_id, event, state_before, self._machine.state, [str(a) for a in actions]
+            )
+            # Orphan disposal: a successful connect the machine did not adopt must be closed (INV-8, F9)
+            if event is Event.CONNECT_SUCCEEDED and Action.ADOPT_CONNECTION not in actions and payload is not None:
+                payload.close()
+            try:
+                for action in actions:
+                    await self._execute(action, payload)
+            except _AdoptFailed:
+                # Post-connect setup failed (e.g. blocked facade): reconnect via the machine (F4)
+                self._post(Event.CONNECTION_LOST)
+            # Wake up wait_for_state() waiters (pulse: set + clear releases all current waiters)
+            self._state_changed.set()
+            self._state_changed.clear()
+
+    async def _execute(self, action: Action, payload: pyatv.interface.AppleTV | None) -> None:
+        """Perform the I/O effect for a machine action. Runs only in the supervisor task."""
+        match action:
+            case Action.START_CONNECT:
+                self._connect_task = self._loop.create_task(self._connect_cycle())
+            case Action.SCHEDULE_RETRY:
+                delay = self._machine.backoff_delay()
+                _LOG.debug("[%s] Trying to connect again in %.1fs", self.log_id, delay)
+                self._retry_task = self._loop.create_task(self._retry_after(delay))
+            case Action.CANCEL_CONNECT:
+                if self._connect_task is not None:
+                    self._connect_task.cancel()
+                    self._connect_task = None
+                if self._retry_task is not None:
+                    self._retry_task.cancel()
+                    self._retry_task = None
+            case Action.ADOPT_CONNECTION:
+                await self._adopt_connection(payload)
+            case Action.TEARDOWN:
+                await self._teardown()
+            case Action.EMIT_CONNECTED:
+                _LOG.debug("[%s] Connected", self.log_id)
+                self.events.emit(EVENTS.CONNECTED, self._device.identifier)
+            case Action.EMIT_DISCONNECTED:
+                self.events.emit(EVENTS.DISCONNECTED, self._device.identifier)
+            case Action.EMIT_AUTH_ERROR:
+                self.events.emit(EVENTS.ERROR, self._device.identifier, "authentication_failed")
+
+    async def _retry_after(self, delay: float) -> None:
+        """Arm the backoff timer and post BACKOFF_ELAPSED when it fires."""
+        await asyncio.sleep(delay)
+        self._post(Event.BACKOFF_ELAPSED)
+
+    async def _adopt_connection(self, atv: pyatv.interface.AppleTV | None) -> None:
+        """
+        Promote a freshly connected handle to the live connection (the only place `_atv` is set, INV-3).
+
+        Wires up listeners, starts push updates and polling, and performs the fresh-connection
+        refresh bootstrap for the app list / output devices (issue #6). pyatv blocks the facade
+        immediately after close(), so any access here can raise BlockedStateError if the
+        connection was lost between the connect cycle returning and this point — any failure
+        raises `_AdoptFailed`, which the supervisor turns into a reconnect (F4).
+        """
+        if atv is None:
+            _LOG.error("[%s] CONNECT_SUCCEEDED without a connection handle", self.log_id)
+            raise _AdoptFailed
+        # Set the listener FIRST so that from this point forward connection_lost/connection_closed
+        # callbacks will fire even if we crash mid-setup.
+        try:
+            self._atv = atv
+            atv.listener = self
+            atv.push_updater.listener = self
+            atv.push_updater.start()
+            atv.audio.listener = self
 
             await self._start_polling()
 
@@ -675,7 +722,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             self._next_app_list_refresh = 0.0
             self._next_output_refresh = 0.0
 
-            if self._atv.features.in_state(FeatureState.Available, FeatureName.AppList):
+            if atv.features.in_state(FeatureState.Available, FeatureName.AppList):
                 self._spawn_task(self._update_app_list())
 
             self._spawn_task(self._update_output_devices())
@@ -683,62 +730,92 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             now = self._loop.time()
             self._next_app_list_refresh = now + APP_LIST_REFRESH_INTERVAL
             self._next_output_refresh = now + OUTPUT_REFRESH_INTERVAL
+        except Exception as err:
+            _LOG.warning("[%s] Connection was lost during post-connect setup: %s", self.log_id, err)
+            raise _AdoptFailed from err
 
-            self.events.emit(EVENTS.CONNECTED, self._device.identifier)
-            _LOG.debug("[%s] Connected", self.log_id)
-        except pyatv.exceptions.BlockedStateError as err:
-            # The pyatv facade was already closed/blocked before we could finish setup.
-            # This happens when the remote side drops the connection in the narrow window
-            # after pyatv.connect() returns but before our listener is fully wired up.
-            # Trigger a clean disconnect so the reconnect loop restarts.
-            _LOG.warning(
-                "[%s] Connection was lost during post-connect setup (%s): %s",
-                self.log_id,
-                err.args[0] if err.args else "blocked",
-                err,
-            )
-            self._handle_disconnect()
-        except Exception as err:  # noqa: BLE001
-            _LOG.exception("[%s] Error during post-connect setup, reconnecting: %s", self.log_id, err)
-            self._handle_disconnect(force=True)
+    async def _teardown(self) -> None:
+        """Stop polling and close the live connection; `close()` is called exactly once per handle (INV-8)."""
+        await self._stop_polling()
+        # Detach before close(): the sync `connection_closed` callback fires inside close() and
+        # must find the machine no longer CONNECTED-with-this-handle (its CONNECTION_LOST is a queued no-op).
+        atv, self._atv = self._atv, None
+        if atv is not None:
+            atv.close()
 
-    async def _connect_once(self) -> bool:
+    async def _stop_supervisor(self) -> None:
+        """Terminate the supervisor task and drain the queue, orphan-disposing pending handles (INV-8/INV-9)."""
+        supervisor = self._supervisor
+        self._supervisor = None
+        if supervisor is not None:
+            supervisor.cancel()
+            with suppress(asyncio.CancelledError):
+                await supervisor
+        # Defensive: STOP normally cancels these via CANCEL_CONNECT, but not on a wait timeout.
+        if self._connect_task is not None:
+            self._connect_task.cancel()
+            self._connect_task = None
+        if self._retry_task is not None:
+            self._retry_task.cancel()
+            self._retry_task = None
+        while not self._event_queue.empty():
+            event, payload = self._event_queue.get_nowait()
+            if event is Event.CONNECT_SUCCEEDED and payload is not None:
+                payload.close()
+
+    async def _connect_cycle(self) -> None:
+        """
+        Run one scan+connect attempt and post the result as an event.
+
+        Never assigns `_atv` (INV-3) — a successful handle is handed to the supervisor via the
+        CONNECT_SUCCEEDED payload. On cancellation it posts nothing and re-raises.
+        """
         try:
-            # Reuse the latest AppleTV instance (Mac and IP) if defined to avoid a scan
-            if self._apple_tv_conf is None:
-                self._apple_tv_conf = await self._find_atv()
-            if self._apple_tv_conf:
-                await self._connect(self._apple_tv_conf)
-                return self._atv is not None
+            atv = await self._connect_attempt()
         except pyatv.exceptions.AuthenticationError:
             _LOG.warning("[%s] Could not connect: authentication error", self.log_id)
-            self._auth_failed = True
-            self.events.emit(EVENTS.ERROR, self._device.identifier, "authentication_failed")
-            return False
+            self._post(Event.AUTH_REJECTED)
         except asyncio.CancelledError:
-            return False
+            raise
         except Exception as err:  # noqa: BLE001
             _LOG.warning("[%s] Could not connect: %s", self.log_id, err)
-            # OSError(101, 'Network is unreachable') or 10065 for Windows
+            self._post(Event.CONNECT_FAILED)
+        else:
+            if atv is None:
+                self._post(Event.CONNECT_FAILED)
+            else:
+                self._post(Event.CONNECT_SUCCEEDED, atv)
+
+    async def _connect_attempt(self) -> pyatv.interface.AppleTV | None:
+        """Resolve the device configuration (cached scan result if available) and connect to it."""
+        try:
+            # Reuse the latest AppleTV configuration (Mac and IP) if defined to avoid a scan
+            if self._apple_tv_conf is None:
+                self._apple_tv_conf = await self._find_atv()
+            if self._apple_tv_conf is None:
+                return None
+            return await self._connect(self._apple_tv_conf)
+        except pyatv.exceptions.AuthenticationError:
+            raise
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            # OSError(101, 'Network is unreachable') or 10065 for Windows: the network stack may
+            # not be ready yet (e.g. right after standby wake) - retry once quickly in-cycle.
             if err.__cause__ and isinstance(err.__cause__, OSError) and err.__cause__.errno in [101, 10065]:
                 _LOG.warning("[%s] Network may not be ready yet %s : retry", self.log_id, err)
                 await asyncio.sleep(ERROR_OS_WAIT)
-                try:
-                    if self._apple_tv_conf is None:
-                        self._apple_tv_conf = await self._find_atv()
-                    if self._apple_tv_conf:
-                        await self._connect(self._apple_tv_conf)
-                        return self._atv is not None
-                except Exception as err2:  # noqa: BLE001
-                    _LOG.warning("[%s] Could not connect: %s", self.log_id, err2)
-                    self._atv = None
-            else:
-                # Reset AppleTV configuration in case this is the wrong conf (changed Mac or IP)
-                self._apple_tv_conf = None
-                self._atv = None
-        return self._atv is not None
+                if self._apple_tv_conf is None:
+                    self._apple_tv_conf = await self._find_atv()
+                if self._apple_tv_conf is None:
+                    return None
+                return await self._connect(self._apple_tv_conf)
+            # Reset AppleTV configuration in case this is the wrong conf (changed Mac or IP),
+            # so the next attempt re-resolves the device with _find_atv()
+            self._apple_tv_conf = None
+            raise
 
-    async def _connect(self, conf: pyatv.interface.BaseConfig) -> None:
+    async def _connect(self, conf: pyatv.interface.BaseConfig) -> pyatv.interface.AppleTV:
         # We try to connect with all the protocols.
         # If something is not ready yet, we try again afterward
         missing_protocols = []
@@ -773,24 +850,7 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             self._device.name = conf.name
 
         async with asyncio.timeout(CONNECT_TIMEOUT):
-            self._atv = await pyatv.connect(conf, self._loop)
-
-    async def disconnect(self) -> None:
-        """Disconnect from ATV."""
-        _LOG.debug("[%s] Disconnecting from device", self.log_id)
-        self._is_enabled = False
-        await self._stop_polling()
-
-        try:
-            if self._atv:
-                self._atv.close()
-            if self._connect_task:
-                self._connect_task.cancel()
-        except Exception as err:  # noqa: BLE001
-            _LOG.exception("[%s] An error occurred while disconnecting: %s", self.log_id, err)
-        finally:
-            self._atv = None
-            self._connect_task = None
+            return await pyatv.connect(conf, self._loop)
 
     def update_config(self, device: AtvDevice) -> None:
         """
@@ -1023,12 +1083,12 @@ class AppleTv(interface.AudioListener, interface.DeviceListener):
             except pyatv.exceptions.BlockedStateError as ex:
                 # The pyatv facade was closed under us; trigger a clean reconnect and exit.
                 _LOG.warning("[%s] Polling: connection blocked, triggering reconnect: %s", self.log_id, ex)
-                self._handle_disconnect()
+                self._post(Event.CONNECTION_LOST)
                 return
             except (pyatv.exceptions.ConnectionFailedError, pyatv.exceptions.ConnectionLostError) as ex:
-                # Connection was lost during a poll; let _handle_disconnect restart the loop.
+                # Connection was lost during a poll; the state machine restarts the connect cycle.
                 _LOG.warning("[%s] Polling: connection lost, triggering reconnect: %s", self.log_id, ex)
-                self._handle_disconnect()
+                self._post(Event.CONNECTION_LOST)
                 return
             except pyatv.exceptions.NotSupportedError:
                 pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,10 @@ convention = "pep257"
     "S101",    # assert is the pytest idiom
     "PLC0415", # local imports are intentional in tests (e.g. purity checks)
     "INP001",  # tests are not a package
+    "SLF001",  # white-box shell tests assert on private state (invariants)
+    "ASYNC110", # bounded predicate polling is fine in tests
+    "TRY003",  # literal exception messages are fine in test fakes
+    "EM101",   # literal exception messages are fine in test fakes
 ]
 
 [tool.ruff.lint.isort]
@@ -79,6 +83,9 @@ max-complexity = 25
 [tool.ruff.format]
 line-ending = "auto"
 quote-style = "double"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.pyright]
 include = ["intg-appletv"]

--- a/tests/unit/test_connection_shell.py
+++ b/tests/unit/test_connection_shell.py
@@ -1,0 +1,323 @@
+"""
+Bucket B — async shell (AppleTv) integration tests with a fake pyatv.
+
+Verifies that the shell honours the machine's actions and the I/O-side invariants of
+spec 001 (INV-3/INV-7/INV-8/INV-9, failure modes F3/F4/F8/F9). pyatv scan/connect are
+monkeypatched to return canned fakes; no network, no real Apple TV.
+
+:copyright: (c) 2026 by Unfolded Circle ApS.
+:license: Mozilla Public License Version 2.0, see LICENSE for more details.
+"""
+
+import asyncio
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+
+import pyatv.exceptions
+import pytest
+from ucapi import StatusCodes
+
+from config import AtvDevice
+from connection_machine import ConnectionState, Event
+import tv
+from tv import EVENTS, AppleTv
+
+IDENTIFIER = "fake-id"
+DEVICE_NAME = "Fake Apple TV"
+
+
+class FakePushUpdater:
+    """Stand-in for pyatv's push updater."""
+
+    def __init__(self, *, fail_start: bool = False) -> None:
+        self.listener: Any = None
+        self.started = False
+        self._fail_start = fail_start
+
+    def start(self) -> None:
+        """Start push updates; optionally simulate a blocked facade (F4)."""
+        if self._fail_start:
+            raise pyatv.exceptions.BlockedStateError("facade is blocked")
+        self.started = True
+
+    def stop(self) -> None:
+        """Stop push updates."""
+        self.started = False
+
+
+class FakeFeatures:
+    """Stand-in for pyatv's feature interface: nothing is available."""
+
+    def in_state(self, *_args: Any) -> bool:
+        """Report every feature as unavailable."""
+        return False
+
+
+class FakeAtv:
+    """Minimal stand-in for a connected pyatv.interface.AppleTV handle."""
+
+    def __init__(self, *, fail_adoption: bool = False, fire_closed_on_close: bool = False) -> None:
+        self.listener: Any = None
+        self.push_updater = FakePushUpdater(fail_start=fail_adoption)
+        self.audio = SimpleNamespace(listener=None, output_devices=[])
+        self.features = FakeFeatures()
+        self.device_info = None
+        self.close_calls = 0
+        self.fire_closed_on_close = fire_closed_on_close
+
+    def close(self) -> None:
+        """Close the handle; optionally re-enter via the sync connection_closed callback (F3)."""
+        self.close_calls += 1
+        if self.fire_closed_on_close and self.listener is not None:
+            self.listener.connection_closed()
+
+
+class FakeConf:
+    """Minimal stand-in for pyatv.interface.BaseConfig."""
+
+    name = DEVICE_NAME
+    identifier = IDENTIFIER
+    all_identifiers = (IDENTIFIER,)
+
+    def get_service(self, _protocol: Any) -> Any:
+        """No services configured (tests use empty credentials)."""
+        return None
+
+    def set_credentials(self, _protocol: Any, _credentials: str) -> None:
+        """Ignore credentials."""
+
+
+class PyatvStub:
+    """Replaces pyatv.scan / pyatv.connect with controllable fakes."""
+
+    def __init__(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.conf: FakeConf | None = FakeConf()
+        self.handles: list[FakeAtv] = []
+        self.connect_gate: asyncio.Event | None = None
+        self.atv_at_connect: list[Any] = []
+        self.device: AppleTv | None = None
+        self.make_handle: Callable[[], FakeAtv] = FakeAtv
+        monkeypatch.setattr(tv.pyatv, "scan", self._scan)
+        monkeypatch.setattr(tv.pyatv, "connect", self._connect)
+
+    async def _scan(self, _loop: Any, identifier: Any = None, hosts: Any = None, **_kwargs: Any) -> list[Any]:
+        del hosts
+        if identifier is None:
+            # output-device refresh scan: nothing else on the network
+            return []
+        return [self.conf] if self.conf is not None else []
+
+    async def _connect(self, _conf: Any, _loop: Any) -> FakeAtv:
+        if self.device is not None:
+            # B-SINGLE-WRITER: capture what the connect cycle sees; must be None (INV-3)
+            self.atv_at_connect.append(self.device._atv)
+        if self.connect_gate is not None:
+            await self.connect_gate.wait()
+        handle = self.make_handle()
+        self.handles.append(handle)
+        return handle
+
+
+@pytest.fixture
+async def stub(monkeypatch: pytest.MonkeyPatch) -> PyatvStub:
+    """Provide the patched pyatv layer."""
+    return PyatvStub(monkeypatch)
+
+
+@pytest.fixture
+async def device(stub: PyatvStub) -> Any:
+    """Provide a fresh AppleTv wired to the fake pyatv; tears down supervisor/polling/tasks."""
+    dev = AppleTv(AtvDevice(identifier=IDENTIFIER, name=DEVICE_NAME, credentials=[]))
+    stub.device = dev
+    yield dev
+    await dev._stop_supervisor()
+    await dev._stop_polling()
+    for task in list(dev._background_tasks):
+        task.cancel()
+
+
+def record_events(dev: AppleTv) -> dict[EVENTS, list[Any]]:
+    """Record emitted driver events per type."""
+    recorded: dict[EVENTS, list[Any]] = {EVENTS.CONNECTED: [], EVENTS.DISCONNECTED: [], EVENTS.ERROR: []}
+    dev.events.on(EVENTS.CONNECTED, recorded[EVENTS.CONNECTED].append)
+    dev.events.on(EVENTS.DISCONNECTED, recorded[EVENTS.DISCONNECTED].append)
+    dev.events.on(EVENTS.ERROR, lambda ident, msg: recorded[EVENTS.ERROR].append((ident, msg)))
+    return recorded
+
+
+async def until(predicate: Callable[[], bool], timeout_s: float = 2.0) -> None:
+    """Wait until the predicate holds (bounded)."""
+    async with asyncio.timeout(timeout_s):
+        while not predicate():
+            await asyncio.sleep(0.01)
+
+
+async def test_b_wire(device: AppleTv, stub: PyatvStub) -> None:
+    """B-WIRE: happy connect adopts once, wires listeners, starts polling, emits one CONNECTED."""
+    recorded = record_events(device)
+    await device.connect()
+    assert await device.wait_for_state({ConnectionState.CONNECTED}, timeout_s=2.0)
+
+    handle = stub.handles[0]
+    assert device._atv is handle
+    assert handle.listener is device
+    assert handle.push_updater.listener is device
+    assert handle.push_updater.started
+    assert handle.audio.listener is device
+    assert device._polling is not None
+    assert recorded[EVENTS.CONNECTED] == [IDENTIFIER]
+    assert recorded[EVENTS.DISCONNECTED] == []
+
+
+async def test_b_single_writer(device: AppleTv, stub: PyatvStub) -> None:
+    """B-SINGLE-WRITER: the connect cycle never assigns `_atv`; only the supervisor adopts (INV-3)."""
+    await device.connect()
+    assert await device.wait_for_state({ConnectionState.CONNECTED}, timeout_s=2.0)
+    # what pyatv.connect saw while running inside the connect task
+    assert stub.atv_at_connect == [None]
+    assert device._atv is stub.handles[0]
+
+
+async def test_b_orphan(device: AppleTv, stub: PyatvStub) -> None:
+    """B-ORPHAN: a late CONNECT_SUCCEEDED after STOP is orphan-disposed, `_atv` stays None (F9, INV-8)."""
+    stub.connect_gate = asyncio.Event()  # keep the connect attempt in flight forever
+    await device.connect()
+    device._post(Event.STOP)
+    assert await device.wait_for_state({ConnectionState.STOPPED}, timeout_s=2.0)
+
+    orphan = FakeAtv()
+    device._post(Event.CONNECT_SUCCEEDED, orphan)  # pyright: ignore[reportArgumentType]
+    await until(lambda: orphan.close_calls == 1)
+    assert device._atv is None
+    assert device.state is ConnectionState.STOPPED
+
+
+async def test_b_reentrant_close(device: AppleTv, stub: PyatvStub) -> None:
+    """B-REENTRANT: close() firing connection_closed synchronously causes no recursion (F3, INV-7)."""
+    stub.make_handle = lambda: FakeAtv(fire_closed_on_close=True)
+    recorded = record_events(device)
+    await device.connect()
+    assert await device.wait_for_state({ConnectionState.CONNECTED}, timeout_s=2.0)
+    first = stub.handles[0]
+
+    # physical drop reported by pyatv
+    device.connection_lost(Exception("drop"))
+    # teardown closes the handle exactly once; the sync re-entrant callback is a queued no-op
+    await until(lambda: first.close_calls == 1)
+    # the machine reconnects; a second handle is adopted
+    await until(lambda: len(stub.handles) == 2 and device._atv is stub.handles[1])
+    assert first.close_calls == 1
+    assert recorded[EVENTS.DISCONNECTED] == [IDENTIFIER]
+    assert recorded[EVENTS.CONNECTED] == [IDENTIFIER, IDENTIFIER]
+
+
+async def test_b_adopt_fail(device: AppleTv, stub: PyatvStub) -> None:
+    """B-ADOPT-FAIL: adoption failure (blocked facade) triggers teardown + reconnect (F4)."""
+    fail_first = True
+
+    def make_handle() -> FakeAtv:
+        nonlocal fail_first
+        handle = FakeAtv(fail_adoption=fail_first)
+        fail_first = False
+        return handle
+
+    stub.make_handle = make_handle
+    recorded = record_events(device)
+    await device.connect()
+
+    # first handle fails adoption and is closed by the machine's TEARDOWN; second connects clean
+    await until(lambda: len(stub.handles) == 2 and device._atv is stub.handles[1])
+    assert stub.handles[0].close_calls == 1
+    # no CONNECTED was emitted for the failed adoption (EMIT_CONNECTED is ordered after ADOPT_CONNECTION)
+    assert recorded[EVENTS.CONNECTED] == [IDENTIFIER]
+    assert device.state is ConnectionState.CONNECTED
+
+
+async def test_b_cmd_wait(device: AppleTv, stub: PyatvStub) -> None:
+    """B-CMD-WAIT: a command while disconnected connects first and succeeds (F8)."""
+
+    @tv.async_handle_atvlib_errors
+    async def fake_command(self: AppleTv) -> StatusCodes:
+        assert self._atv is not None
+        return StatusCodes.OK
+
+    assert device.state is ConnectionState.STOPPED
+    result = await fake_command(device)
+    assert result == StatusCodes.OK
+    assert device.state is ConnectionState.CONNECTED
+    assert stub.handles  # a real (fake) connection was established for the command
+
+
+async def test_b_cmd_503(device: AppleTv, stub: PyatvStub, monkeypatch: pytest.MonkeyPatch) -> None:
+    """B-CMD-503: a command that cannot connect returns SERVICE_UNAVAILABLE without blocking past the window."""
+    monkeypatch.setattr(tv, "CONNECT_WAIT_FOR_COMMAND", 0.2)
+    stub.conf = None  # scan never finds the device
+
+    @tv.async_handle_atvlib_errors
+    async def fake_command(_self: AppleTv) -> StatusCodes:
+        return StatusCodes.OK
+
+    result = await fake_command(device)
+    assert result == StatusCodes.SERVICE_UNAVAILABLE
+    assert device._atv is None
+
+
+async def test_b_disconnect_await(device: AppleTv, stub: PyatvStub) -> None:
+    """B-DISCONNECT-AWAIT: disconnect() returns only after STOPPED; handle closed; supervisor gone."""
+    recorded = record_events(device)
+    await device.connect()
+    assert await device.wait_for_state({ConnectionState.CONNECTED}, timeout_s=2.0)
+
+    await device.disconnect()
+    assert device.state is ConnectionState.STOPPED
+    assert device._atv is None
+    assert stub.handles[0].close_calls == 1
+    assert device._supervisor is None  # INV-9: no leaked task
+    assert recorded[EVENTS.DISCONNECTED] == [IDENTIFIER]
+
+
+async def test_b_shutdown_drains_queue(device: AppleTv, stub: PyatvStub) -> None:
+    """B-SHUTDOWN: supervisor termination orphan-disposes a queued late CONNECT_SUCCEEDED (INV-8, INV-9)."""
+    stub.connect_gate = asyncio.Event()  # connect attempt stays in flight
+    await device.connect()
+    device._post(Event.STOP)
+    assert await device.wait_for_state({ConnectionState.STOPPED}, timeout_s=2.0)
+
+    # a late success lands in the queue just as the supervisor is being stopped
+    late = FakeAtv()
+    device._post(Event.CONNECT_SUCCEEDED, late)  # pyright: ignore[reportArgumentType]
+    await device._stop_supervisor()
+
+    assert late.close_calls == 1
+    assert device._atv is None
+    assert device._supervisor is None
+    assert device._event_queue.empty()
+
+
+async def test_b_no_supervisor(stub: PyatvStub) -> None:
+    """B-NO-SUPERVISOR: disconnect() on a never-connected (pairing-only) instance returns immediately."""
+    del stub
+    dev = AppleTv(AtvDevice(identifier=IDENTIFIER, name=DEVICE_NAME, credentials=[]))
+    async with asyncio.timeout(1.0):  # far below STOP_TIMEOUT: must not wait for the state machine
+        await dev.disconnect()
+    assert dev._supervisor is None
+    assert dev.state is ConnectionState.STOPPED
+
+
+async def test_b_refresh_bootstrap(device: AppleTv, stub: PyatvStub) -> None:
+    """B-REFRESH-BOOTSTRAP: reconnect re-arms the app-list latch and refresh timers (issue 6 preserved)."""
+    await device.connect()
+    assert await device.wait_for_state({ConnectionState.CONNECTED}, timeout_s=2.0)
+
+    # simulate a device that latched "not supported" and stale timers during the previous connection
+    device._app_list_supported = False
+    device._next_app_list_refresh = 0.0
+    device._next_output_refresh = 0.0
+
+    device.connection_lost(Exception("drop"))
+    await until(lambda: len(stub.handles) == 2 and device._atv is stub.handles[1])
+
+    assert device._app_list_supported is True
+    assert device._next_app_list_refresh > 0.0
+    assert device._next_output_refresh > 0.0


### PR DESCRIPTION
## Summary

PR 2 of the connection-lifecycle refactor ([spec 001](docs/specs/001-connection-lifecycle-state-machine.md), follows #158). This is the behavioral change: `AppleTv` in `tv.py` is now driven by the pure `ConnectionMachine` from phase 1, wrapped in a thin async shell.

### How it works
Every trigger — external `connect()`/`disconnect()`, pyatv's `connection_lost`/`connection_closed` callbacks, connect-cycle results, poll-worker and command-decorator drops — is posted as an event onto a **single `asyncio.Queue`** consumed by **one supervisor coroutine**, which runs the machine's returned actions in order. The machine is pure and the queue has exactly one consumer, so there are **no locks** and the historical reconnection races are structurally impossible.

### Key properties (spec invariants)
- **Single `_atv` writer (INV-3):** only the supervisor assigns `_atv` (adopt/teardown); the connect cycle hands its handle over via the `CONNECT_SUCCEEDED` payload; `_connect` now *returns* the handle.
- **Callbacks never block (INV-7):** `connection_lost`/`connection_closed` collapse to a one-line `_post(CONNECTION_LOST)`; duplicates land in a state where they are no-op table cells → **exactly one `DISCONNECTED` per physical drop (INV-5, F2)**.
- **No re-entrant close / no leaked handles (INV-8):** teardown detaches `_atv` before `close()`; a `CONNECT_SUCCEEDED` that the machine does not adopt (e.g. racing a `STOP`) is orphan-disposed (F9).
- **No task leaks (INV-9):** `disconnect()` awaits `STOPPED` (bounded by `STOP_TIMEOUT`), terminates the supervisor and drains the queue; it is an immediate no-op on never-supervised pairing-only instances (setup flow).
- **Auth is terminal until re-armed (INV-6):** bad credentials → `AUTH_FAILED`, one `EVENTS.ERROR`, no autonomous retry; any external `START` re-arms exactly one fresh cycle (same semantics as the merged #150 fix).
- **Adoption failure (blocked facade during post-connect setup) → `CONNECTION_LOST` → clean reconnect (F4).**

### Preserved behaviour
- Fresh-connection app-list/output-device **refresh bootstrap** (issue #6 fix) now lives in `ADOPT_CONNECTION`.
- `_apple_tv_conf` **cache reuse/reset semantics** (changed IP/MAC recovery) and the `OSError` errno 101/10065 quick retry live on in `_connect_attempt`.
- Backoff curve unchanged (attempts × 2 s, capped at 30 s) — now owned by the machine.
- **Public API unchanged**: `connect()` / `disconnect()` / `is_enabled` / `update_config()` — `driver.py`, `media_player.py`, `remote.py` and `setup_flow.py` needed **zero changes**.

### Deleted (AC-4)
`_handle_disconnect` (+ `force`), `_start_connect_loop`, `_connect_loop`, `_connect_once`, `_backoff`, the `_is_enabled`/`_auth_failed`/`_connection_attempts` fields, and the unused `EVENTS.CONNECTING`. `is_enabled` derives from machine state.

### Tests (Bucket B)
`tests/unit/test_connection_shell.py` with a fake pyatv layer (patched `scan`/`connect`, `FakeAtv` with optional sync re-entrant close and adoption failure): B-WIRE, B-SINGLE-WRITER, B-ORPHAN, B-REENTRANT, B-ADOPT-FAIL, B-CMD-WAIT, B-CMD-503, B-DISCONNECT-AWAIT, B-SHUTDOWN, B-NO-SUPERVISOR, B-REFRESH-BOOTSTRAP.

## Verification
- `pytest tests/` — **52 passed** (41 Bucket A + 11 Bucket B)
- `ruff check` + `ruff format --check` clean; `pyright` (strict) 0 errors
- Driver smoke-start with empty config: clean startup, discovery + ucapi publish OK

## Outstanding
- **AC-9 (real-device smoke test)** needs a physical Apple TV: connect, unplug/reboot for reconnect, standby enter/exit, wrong credentials → auth error. @zehnm
- Phase 4 (entity-state mapping verification) follows as PR 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)